### PR TITLE
Added nub_by

### DIFF
--- a/lib/vsc/utils/missing.py
+++ b/lib/vsc/utils/missing.py
@@ -66,6 +66,9 @@ def nub(list_):
 def nub_by(list_, predicate):
     """Returns the elements of a list that fullfil the predicate.
 
+    For any pair of elements in the resulting list, the predicate does not hold. For example, the nub above
+    can be expressed as nub_by(list, lambda x, y: x == y).
+
     @type list_: a list of items of some type t
     @type predicate: a function that takes two elements of type t and returns a bool
 


### PR DESCRIPTION
nub_by aism to retain elements from a list, such that no two elements cause the given predicate to become true, i.e., according to the predicate, they are all different.
