### PR TITLE
Put the rebuilt RPM under ./dist

### DIFF
--- a/bdist_rpm.sh
+++ b/bdist_rpm.sh
@@ -80,6 +80,7 @@ for package in $ALL_PACKAGES; do
              --change-spec-provides="sed -e 's/${package}/python-${package}/g'" \
              --change-spec-requires="sed -r 's/^Requires:(\s\s*)(${requirements})/Requires:\1python-\2/'" \
              --change-spec-preamble="sed -e 's/^\(Release:\s\s*\)\(.*\)\s*$/\1${release}.ug/'" \
+             --directory=./dist/ \
              ${edit} -n -p ${rpm_target}
    echo "Finished building RPM for $package"
 done


### PR DESCRIPTION
`bdist_rpm` puts the built RPMs under ~/rpmbuild/RPMS, which is bad for our `clusterbuildrpm`.

Instead, it's way easier to grab the RPM if it lies under ./dist, with the misnamed vsc-processcontrol one.

Same as hpcugent/vsc-processcontrol#5 .
