### PR TITLE
close handler when log is disabled

### DIFF
--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -469,7 +469,7 @@ def _logToSomething(handlerclass, handleropts, loggeroption, enable=True, name=N
             else:  # remove the handler set with this loggeroption
                 handler = getattr(logger, loggeroption)
                 logger.removeHandler(handler)
-                if hasattr(handler, 'close') and callable(handle.close):
+                if hasattr(handler, 'close') and callable(handler.close):
                     handler.close()
         else:
             logger.removeHandler(handler)


### PR DESCRIPTION
When a log is disabled using `enable=False` , the log handler should also be close, not only removed.

Required for EasyBuild, see also https://github.com/hpcugent/easybuild-framework/pull/620.
