### PR TITLE
Fix the declaration of setuptools.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ PACKAGE = {
                  'python-vsc-packages-logging = 0.14',
                  'python-vsc-packages-utils = 0.11'],
     'scripts': ['bin/logdaemon.py', 'bin/startlogdaemon.sh', 'bin/bdist_rpm.sh'],
-    'install_requires' : ['python-setuptools']
+    'install_requires' : ['setuptools'],
 }
 
 if __name__ == '__main__':


### PR DESCRIPTION
It will be mangled by bdist_rpm, but we need the unmangled version for running easy_install.
