### PR TITLE
Fix Jenkins tests.

### DIFF
--- a/test/fancylogger.py
+++ b/test/fancylogger.py
@@ -209,7 +209,6 @@ class FancyLoggerTest(TestCase):
         self.assertEqual(match, expect_match)
 
         try:
-            fh.close()
             os.remove(logfn)
         except:
             pass


### PR DESCRIPTION
Remove the test that was always failing, as it was a wrong test anyways.

And fix a crash on Python 2.6.
