### PR TITLE
make existing code Py3 compatible (WIP)

### DIFF
--- a/lib/vsc/utils/asyncprocess.py
+++ b/lib/vsc/utils/asyncprocess.py
@@ -107,8 +107,10 @@ class Popen(subprocess.Popen):
             return 0
 
         try:
+            if isinstance(inp, str):
+                inp = inp.encode()
             written = os.write(self.stdin.fileno(), inp)
-        except OSError, why:
+        except OSError as why:
             if why[0] == errno.EPIPE:  # broken pipe
                 return self._close('stdin')
             raise
@@ -177,7 +179,7 @@ def recv_some(p, t=.1, e=False, tr=5, stderr=False, maxread=None):
             len_y += len(r)
         else:
             time.sleep(max((x - time.time()) / tr, 0))
-    return ''.join(y)
+    return b''.join(y)
 
 
 def send_all(p, data):
@@ -188,4 +190,9 @@ def send_all(p, data):
         sent = p.send(data)
         if sent is None:
             raise Exception(MESSAGE)
-        data = buffer(data, sent)
+        try:
+            if isinstance(data, str):
+                data = data.encode()
+            data = memoryview(data) #[:sent]  # sent?
+        except NameError:
+            data = buffer(data, sent)

--- a/lib/vsc/utils/daemon.py
+++ b/lib/vsc/utils/daemon.py
@@ -40,7 +40,7 @@ class Daemon:
             if pid > 0:
                 # exit first parent
                 sys.exit(0)
-        except OSError, e:
+        except OSError as e:
             sys.stderr.write("fork #1 failed: %d (%s)\n" % (e.errno, e.strerror))
             sys.exit(1)
 
@@ -55,7 +55,7 @@ class Daemon:
             if pid > 0:
                 # exit from second parent
                 sys.exit(0)
-        except OSError, e:
+        except OSError as e:
             sys.stderr.write("fork #2 failed: %d (%s)\n" % (e.errno, e.strerror))
             sys.exit(1)
 
@@ -120,7 +120,7 @@ class Daemon:
             while 1:
                 os.kill(pid, SIGTERM)
                 time.sleep(0.1)
-        except OSError, err:
+        except OSError as err:
             err = str(err)
             if err.find("No such process") > 0:
                 if os.path.exists(self.pidfile):

--- a/lib/vsc/utils/dateandtime.py
+++ b/lib/vsc/utils/dateandtime.py
@@ -144,7 +144,7 @@ class FancyMonth:
     def get_other(self, shift=-1):
         """Return month that is shifted shift months: negative integer is in past, positive is in future"""
         new = self.date.year * 12 + self.date.month - 1 + shift
-        return self.__class__(date(new // 12, new % 12 + 1, 01))
+        return self.__class__(date(new // 12, new % 12 + 1, 1))
 
     def interval(self, otherdate):
         """Return time ordered list of months between date and otherdate"""

--- a/lib/vsc/utils/frozendict.py
+++ b/lib/vsc/utils/frozendict.py
@@ -17,14 +17,20 @@
 # IN THE SOFTWARE
 
 import operator
-from UserDict import DictMixin
-
+import sys
+from distutils.version import LooseVersion
+pyver = sys.version.split(' ')[0]
+if LooseVersion(pyver) < LooseVersion('3.0'):
+    from UserDict import DictMixin as MutableMapping
+else:
+    # see http://stackoverflow.com/questions/11165188/how-to-achieve-the-functionality-of-userdict-dictmixin-in-python-3
+    from collections import MutableMapping
 
 # minor adjustments:
 # * renamed to FrozenDict
 # * deriving from DictMixin instead of collections.Mapping to make it Python 2.4 compatible
 #   see also http://docs.python.org/2/library/userdict.html#UserDict.DictMixin
-class FrozenDict(object, DictMixin):
+class FrozenDict(MutableMapping, object):
 
     def __init__(self, *args, **kwargs):
         self.__dict = dict(*args, **kwargs)

--- a/lib/vsc/utils/missing.py
+++ b/lib/vsc/utils/missing.py
@@ -268,7 +268,7 @@ class FrozenDictKnownKeys(FrozenDict):
         """Redefine __getitem__ to provide a better KeyError message."""
         try:
             return super(FrozenDictKnownKeys, self).__getitem__(key, *args, **kwargs)
-        except KeyError, err:
+        except KeyError as err:
             if key in self.KNOWN_KEYS:
                 raise KeyError(err)
             else:
@@ -334,7 +334,7 @@ class TryOrFail(object):
             for i in xrange(0, self.n):
                 try:
                     return function(*args, **kwargs)
-                except self.exceptions, err:
+                except self.exceptions as err:
                     if i == self.n - 1:
                         raise
                     log.exception("try_or_fail caught an exception - attempt %d: %s" % (i, err))

--- a/lib/vsc/utils/optcomplete.py
+++ b/lib/vsc/utils/optcomplete.py
@@ -418,7 +418,7 @@ def autocomplete(parser, arg_completer=None, opt_completer=None, subcmd_complete
 
     # If we are not requested for complete, simply return silently, let the code
     # caller complete. This is the normal path of execution.
-    if not os.environ.has_key(OPTCOMPLETE_ENVIRONMENT):
+    if not OPTCOMPLETE_ENVIRONMENT in os.environ:
         return
     # After this point we should never return, only sys.exit(1)
 
@@ -544,7 +544,7 @@ def autocomplete(parser, arg_completer=None, opt_completer=None, subcmd_complete
     if isinstance(completions, basestring):
         # is a bash command, just run it
         if SHELL in (BASH,):  # TODO: zsh
-            print completions
+            print(completions)
         else:
             raise Exception("Commands are unsupported by this shell %s" % SHELL)
     else:
@@ -555,9 +555,9 @@ def autocomplete(parser, arg_completer=None, opt_completer=None, subcmd_complete
 
         # Save results
         if SHELL == "bash":
-            print 'COMPREPLY=(' + completions + ')'
+            print('COMPREPLY=(' + completions + ')')
         else:
-            print completions
+            print(completions)
 
     # Print debug output (if needed).  You can keep a shell with 'tail -f' to
     # the log file to monitor what is happening.

--- a/lib/vsc/utils/rest.py
+++ b/lib/vsc/utils/rest.py
@@ -35,14 +35,21 @@ based on https://github.com/jpaugh/agithub/commit/1e2575825b165c1cb7cbd85c22e256
 """
 import base64
 import urllib
-import urllib2
+import sys
 try:
     import json
 except ImportError:
     import simplejson as json
 
+from distutils.version import LooseVersion
 from vsc.utils import fancylogger
 from vsc.utils.missing import partial
+
+pyver = sys.version.split(' ')[0]
+if LooseVersion(pyver) < LooseVersion('3.0'):
+    from urllib2 import HTTPSHandler, Request, build_opener
+else:
+    from urllib.request import HTTPSHandler, Request, build_opener
 
 
 class Client(object):
@@ -85,8 +92,8 @@ class Client(object):
         else:
             self.user_agent = user_agent
 
-        handler = urllib2.HTTPSHandler()
-        self.opener = urllib2.build_opener(handler)
+        handler = HTTPSHandler()
+        self.opener = build_opener(handler)
 
         if username is not None:
             if password is None and token is None:
@@ -194,7 +201,7 @@ class Client(object):
             sep = '/'
         else:
             sep = ''
-        request = urllib2.Request(self.url + sep + url, data=body)
+        request = Request(self.url + sep + url, data=body)
         for header, value in headers.iteritems():
             request.add_header(header, value)
         request.get_method = lambda: method

--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -307,7 +307,7 @@ class Run(object):
         if self.cmd is None:
             self.log.raiseExcpetion("_make_shell_command: no cmd set.")
 
-        if isinstance(self.cmd, basestring):
+        if isinstance(self.cmd, str):
             self._shellcmd = self.cmd
         elif isinstance(self.cmd, (list, tuple,)):
             self._shellcmd = " ".join(self.cmd)
@@ -356,7 +356,7 @@ class Run(object):
         if readsize is None:
             readsize = -1  # read all
         self.log.debug("_read_process: going to read with readsize %s" % readsize)
-        out = self._process.stdout.read(readsize)
+        out = self._process.stdout.read(readsize).decode()
         return out
 
     def _post_exitcode(self):
@@ -384,7 +384,7 @@ class Run(object):
         """
         if tasks is None:
             self.log.error("killtasks no tasks passed")
-        elif isinstance(tasks, basestring):
+        elif isinstance(tasks, str):
             try:
                 tasks = [int(tasks)]
             except:
@@ -397,11 +397,11 @@ class Run(object):
                 if kill_pgid:
                     os.killpg(pgid, sig)
                 self.log.debug("Killed %s with signal %s" % (pid, sig))
-            except OSError, err:
+            except OSError as err:
                 # ERSCH is no such process, so no issue
                 if not err.errno == errno.ESRCH:
                     self.log.error("Failed to kill %s: %s" % (pid, err))
-            except Exception, err:
+            except Exception as err:
                 self.log.error("Failed to kill %s: %s" % (pid, err))
 
     def stop_tasks(self):
@@ -480,7 +480,7 @@ class RunLoop(Run):
 
             # process after updating the self._process_ vars
             self._loop_process_output_final(output)
-        except RunLoopException, err:
+        except RunLoopException as err:
             self.log.debug('RunLoopException %s' % err)
             self._process_output = err.output
             self._process_exitcode = err.code
@@ -696,7 +696,7 @@ class RunQA(RunLoop, RunAsync):
 
         def process_answers(answers):
             """Construct list of newline-terminated answers (as strings)."""
-            if isinstance(answers, basestring):
+            if isinstance(answers, str):
                 answers = [answers]
             elif isinstance(answers, list):
                 # list is manipulated when answering matching question, so take a copy

--- a/test/dateandtime.py
+++ b/test/dateandtime.py
@@ -29,6 +29,9 @@ Python module for handling data and time strings.
 
 @author: Stijn De Weirdt (Ghent University)
 """
+# required to avoid Py2 interpreting "print('a', 'b')" as printing a tuple
+from __future__ import print_function
+
 import datetime
 import os
 from unittest import TestCase, TestLoader
@@ -85,34 +88,34 @@ if __name__ == '__main__':
     """
 #    # date_parser
 #    testdate = datetime.date(1970, 1, 1)
-#    print date_parser('1970-01-01') == testdate
-#    print date_parser('1970-1-1') == testdate
+#    print(date_parser('1970-01-01') == testdate)
+#    print(date_parser('1970-1-1') == testdate)
 #
 #    today = datetime.date.today()
 #    beginthismonth = datetime.date(today.year, today.month, 1)
-#    print date_parser('BEGINTHISMONTH') == beginthismonth
+#    print(date_parser('BEGINTHISMONTH') == beginthismonth)
 #
 #    endapril = datetime.date(today.year, 4, 30)
-#    print date_parser('ENDAPRIL') == endapril
+#    print(date_parser('ENDAPRIL') == endapril)
 
 #    # datetime_parser
 #    testdate = datetime.datetime(1970, 1, 1)
-#    print datetime_parser('1970-01-01') , testdate
-#    print datetime_parser('1970-1-1'), testdate
+#    print(datetime_parser('1970-01-01') , testdate)
+#    print(datetime_parser('1970-1-1'), testdate)
 #
 #    today = datetime.datetime.today()
 #    beginthismonth = datetime.datetime(today.year, today.month, 1, 12, 1)
-#    print datetime_parser('BEGINTHISMONTH 12:1') , beginthismonth
+#    print(datetime_parser('BEGINTHISMONTH 12:1') , beginthismonth)
 #
 #    endapril = datetime.datetime(today.year, 4, 30, 12, 1, 1, 1)
-#    print datetime_parser('ENDAPRIL 12:01:01.000001') , endapril
+#    print(datetime_parser('ENDAPRIL 12:01:01.000001') , endapril)
 
     ## FancyMonth
     today = datetime.date.today()
     endapril = datetime.date(today.year, 4, 10)
     f = FancyMonth(endapril)
-    print f.nrdays, 30  # nr days in month
+    print(f.nrdays, 30)  # nr days in month
 
     may2nd = datetime.date(today.year, 5, 2)
-    print f.number(may2nd), 2  # spans 2 months
-    print [x.nrdays for x in f.interval(may2nd)], [30, 31]  # interval returns FancyMonth instances
+    print(f.number(may2nd), 2)  # spans 2 months
+    print([x.nrdays for x in f.interval(may2nd)], [30, 31])  # interval returns FancyMonth instances

--- a/test/fancylogger.py
+++ b/test/fancylogger.py
@@ -34,12 +34,18 @@ import logging
 import os
 import re
 import sys
-from StringIO import StringIO
 import tempfile
+from distutils.version import LooseVersion
 from test.utilities import EnhancedTestCase
 from unittest import TestLoader, main
 
 from vsc.utils import fancylogger
+
+pyver = sys.version.split(' ')[0]
+if LooseVersion(pyver) < LooseVersion('3.0'):
+    from StringIO import StringIO
+else:
+    from io import StringIO
 
 MSG = "This is a test log message."
 # message format: '<date> <time> <type> <source location> <message>'
@@ -269,7 +275,7 @@ class FancyLoggerTest(EnhancedTestCase):
         handler = fancylogger.logToScreen()
         logger = fancylogger.getLogger(fname=False, clsname=False)
         logger.warn("blabla")
-        print stringfile.getvalue()
+        print(stringfile.getvalue())
         # this will only hold in debug mode, so also disable the test
         if  __debug__:
             self.assertTrue('FancyLoggerTest' in stringfile.getvalue())

--- a/test/generaloption.py
+++ b/test/generaloption.py
@@ -310,7 +310,7 @@ strlist=x,y
 opt1=value1
 
 """
-        tmp1 = NamedTemporaryFile()
+        tmp1 = NamedTemporaryFile(mode='w+')
         tmp1.write(CONFIGFILE1)
         tmp1.flush()  # flush, otherwise empty
 
@@ -340,7 +340,7 @@ justatest=0
 debug=1
 
 """
-        tmp2 = NamedTemporaryFile()
+        tmp2 = NamedTemporaryFile(mode='w+')
         tmp2.write(CONFIGFILE2)
         tmp2.flush()  # flush, otherwise empty
 

--- a/test/missing.py
+++ b/test/missing.py
@@ -112,7 +112,7 @@ def generate_random_dag():
     """
     myseed = randint(0, sys.maxint)
     seed(myseed)
-    print "testing with random seed", myseed
+    print("testing with random seed %s" % myseed)
     edge_probability = randint(10, 30)
     ranks = randint(3, 10)
     graph = {}

--- a/test/optcomplete.py
+++ b/test/optcomplete.py
@@ -82,7 +82,7 @@ class TestOptcomplete(TestCase):
         # missing mandatory CALL_ARGS
         try:
             nc()
-        except Exception, e:
+        except Exception as e:
             pass
 
         self.assertEqual(e.__class__, CompleterMissingCallArgument)

--- a/test/runner.py
+++ b/test/runner.py
@@ -24,7 +24,7 @@ suite = unittest.TestSuite([x.suite() for x in (a, td, tg, tf, tm, trest, trun, 
 try:
     import xmlrunner
     rs = xmlrunner.XMLTestRunner(output="test-reports").run(suite)
-except ImportError, err:
+except ImportError as err:
     rs = unittest.TextTestRunner().run(suite)
 
 if not rs.wasSuccessful():

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -46,7 +46,7 @@ class EnhancedTestCase(TestCase):
             str_kwargs = ', '.join(['='.join([k,str(v)]) for (k,v) in kwargs.items()])
             str_args = ', '.join(map(str, args) + [str_kwargs])
             self.assertTrue(False, "Expected errors with %s(%s) call should occur" % (call.__name__, str_args))
-        except error, err:
+        except error as err:
             if hasattr(err, 'msg'):
                 msg = err.msg
             elif hasattr(err, 'message'):


### PR DESCRIPTION
This effectively makes `vsc-base` require Python 2.6, so be careful when merging this in (EasyBuild, which needs `vsc-base` will only move to Python 2.6 early 2015).

Currently WIP, not all unit tests pass yet with Python3 (but they still do using Python2.6).

Maybe this should include a bump to v2.0?