### PR TITLE
stop using deprecated 'message' attribute

### DIFF
--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -1027,7 +1027,7 @@ class GeneralOption(object):
         try:
             (self.options, self.args) = self.parser.parse_args(options_list)
         except SystemExit, err:
-            self.log.debug("parseoptions: parse_args err %s code %s" % (msg, err.code))
+            self.log.debug("parseoptions: parse_args err %s code %s" % (err, err.code))
             if self.no_system_exit:
                 return
             else:

--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -1027,11 +1027,6 @@ class GeneralOption(object):
         try:
             (self.options, self.args) = self.parser.parse_args(options_list)
         except SystemExit, err:
-            try:
-                msg = err.message
-            except AttributeError:
-                # py2.4
-                msg = str(err)
             self.log.debug("parseoptions: parse_args err %s code %s" % (msg, err.code))
             if self.no_system_exit:
                 return

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 
 import vsc.install.shared_setup as shared_setup
-from vsc.install.shared_setup import ag, jt, sdw
+from vsc.install.shared_setup import ag, kh, jt, sdw
 
 def remove_bdist_rpm_source_file():
     """List of files to remove from the (source) RPM."""
@@ -52,9 +52,9 @@ shared_setup.SHARED_TARGET.update({
 
 PACKAGE = {
     'name': 'vsc-base',
-    'version': '2.0.0',
-    'author': [sdw, jt, ag],
-    'maintainer': [sdw, jt, ag],
+    'version': '2.0.1',
+    'author': [sdw, jt, ag, kh],
+    'maintainer': [sdw, jt, ag, kh],
     'packages': ['vsc', 'vsc.utils', 'vsc.install'],
     'scripts': ['bin/logdaemon.py', 'bin/startlogdaemon.sh', 'bin/bdist_rpm.sh', 'bin/optcomplete.bash'],
     'install_requires' : ['setuptools'],


### PR DESCRIPTION
EasyBuild users sometimes run into this:

```
<prefix>vsc/utils/generaloption.py:1031: DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
```

But there's really no reason to use `err.message anymore:

Python 2.6:
```
$ python
Python 2.6.6 (r266:84292, Jan 22 2014, 05:06:49) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-3)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> class A():
...  pass
... 
>>> a=A()
>>> try:a.foo
... except AttributeError, err: print str(err)
... 
A instance has no attribute 'foo'
```

Python 2.7:
```
$ python
Python 2.7.6 (default, Sep  9 2014, 15:04:36) 
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.39)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> class A():
...   pass
... 
>>> a=A()
>>> try:a.foo
... except AttributeError, err: print err.message
... 
A instance has no attribute 'foo'
>>> try:a.foo
... except AttributeError, err: print str(err)
... 
A instance has no attribute 'foo'
```