### PR TITLE
add support for (un)setting options back to None in configuration files

### DIFF
--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -30,6 +30,7 @@ A class that can be used to generated options to python scripts in a general way
 
 @author: Stijn De Weirdt (Ghent University)
 @author: Jens Timmerman (Ghent University)
+@author: Kenneth Hoste (Ghent University)
 """
 
 import ConfigParser
@@ -41,8 +42,9 @@ import re
 import StringIO
 import sys
 import textwrap
-from optparse import OptionParser, OptionGroup, Option, Values, HelpFormatter
-from optparse import BadOptionError, SUPPRESS_USAGE, NO_DEFAULT, OptionValueError
+from distutils.version import LooseVersion
+from optparse import OptionParser, OptionGroup, Option, Values
+from optparse import BadOptionError, SUPPRESS_USAGE, OptionValueError
 from optparse import SUPPRESS_HELP as nohelp  # supported in optparse of python v2.4
 from optparse import _ as _gettext  # this is gettext normally
 from vsc.utils.dateandtime import date_parser, datetime_parser
@@ -1058,7 +1060,16 @@ class GeneralOption(object):
                 the 2nd level key,value is the key=value. 
                 All section names, keys and values are converted to strings.
         """
-        self.configfile_parser = self.CONFIGFILE_PARSER()
+        # allow_no_value indicates that options can be unset (a.k.a. set to None) in configuration files,
+        # by specifying them without a value (for example: 'foo' rather than 'foo = bar')
+        # note: only available with Python 2.7
+        # see also https://docs.python.org/2/library/configparser.html#ConfigParser.RawConfigParser
+        if LooseVersion(sys.version) >= LooseVersion('2.7'):
+            self.log.debug("Initializing configfile parser, enable allowing to unset options")
+            self.configfile_parser = self.CONFIGFILE_PARSER(allow_no_value=True)
+        else:
+            self.log.debug("Initializing configfile parser, unsetting of options is not supported < Py2.7")
+            self.configfile_parser = self.CONFIGFILE_PARSER()
 
         # make case sensitive
         if self.CONFIGFILE_CASESENSITIVE:
@@ -1218,10 +1229,15 @@ class GeneralOption(object):
                             self.log.debug(("parseconfigfiles: no enable/disable, not trying to set boolean-valued "
                                             "option %s via cmdline, just setting value to %s" % (opt_name, newval)))
                             configfile_values[opt_dest] = newval
-                    else:
+                    # check whether value is None via .get()
+                    # .items() returns extrapolated values, None will always be transformed to '' there
+                    elif self.configfile_parser.get(section, opt) is not None:
+                        self.log.debug("parseconfigfiles: appending option %s (value: %s) to cmdline" % (opt_name, val))
                         configfile_cmdline_dest.append(opt_dest)
                         configfile_cmdline.append("--%s" % opt_name)
                         configfile_cmdline.append(val)
+                    else:
+                        self.log.debug("parseconfigfiles: not passing through option %s with None value" % opt_name)
 
         # reparse
         self.log.debug('parseconfigfiles: going to parse options through cmdline %s' % configfile_cmdline)

--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -1065,10 +1065,10 @@ class GeneralOption(object):
         # note: only available with Python 2.7
         # see also https://docs.python.org/2/library/configparser.html#ConfigParser.RawConfigParser
         if LooseVersion(sys.version) >= LooseVersion('2.7'):
-            self.log.debug("Initializing configfile parser, enable allowing to unset options")
+            self.log.debug("Initializing configfile parser, allowing to unset options is enabled")
             self.configfile_parser = self.CONFIGFILE_PARSER(allow_no_value=True)
         else:
-            self.log.debug("Initializing configfile parser, unsetting of options is not supported < Py2.7")
+            self.log.warning("Initializing configfile parser, unsetting of options is not supported < Py2.7")
             self.configfile_parser = self.CONFIGFILE_PARSER()
 
         # make case sensitive

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 
 import vsc.install.shared_setup as shared_setup
-from vsc.install.shared_setup import ag, jt, sdw
+from vsc.install.shared_setup import ag, jt, sdw, kh
 
 def remove_bdist_rpm_source_file():
     """List of files to remove from the (source) RPM."""
@@ -52,9 +52,9 @@ shared_setup.SHARED_TARGET.update({
 
 PACKAGE = {
     'name': 'vsc-base',
-    'version': '2.0.1',
-    'author': [sdw, jt, ag],
-    'maintainer': [sdw, jt, ag],
+    'version': '2.0.2',
+    'author': [sdw, jt, ag, kh],
+    'maintainer': [sdw, jt, ag, kh],
     'packages': ['vsc', 'vsc.utils', 'vsc.install'],
     'scripts': ['bin/logdaemon.py', 'bin/startlogdaemon.sh', 'bin/bdist_rpm.sh', 'bin/optcomplete.bash'],
     'install_requires' : ['setuptools'],

--- a/test/generaloption.py
+++ b/test/generaloption.py
@@ -27,11 +27,15 @@
 Unit tests for generaloption
 
 @author: Stijn De Weirdt (Ghent University)
+@author: Kenneth Hoste (Ghent University)
 """
 import datetime
 import logging
 import os
 import re
+import sys
+from ConfigParser import ParsingError
+from distutils.version import LooseVersion
 from tempfile import NamedTemporaryFile
 from unittest import TestCase, TestLoader, main
 
@@ -40,6 +44,7 @@ from vsc.utils.generaloption import GeneralOption
 from vsc.utils.missing import shell_quote, shell_unquote
 from vsc.utils.optcomplete import gen_cmdline
 from vsc.utils.run import run_simple
+from vsc.utils.testing import EnhancedTestCase
 
 _init_configfiles = ['/not/a/real/configfile']
 
@@ -50,12 +55,14 @@ class TestOption1(GeneralOption):
     def base_options(self):
         """Make base options"""
         self._opts_base = {
-            "base":("Long and short base option", None, "store_true", False, 'b'),
-            "longbase":("Long-only base option", None, "store_true", True),
-            "justatest":("Another long based option", None, "store_true", True),
-            "store":("Store option", None, "store", None),
-            "store-with-dash":("Store option with dash in name", None, "store", None),
-            "aregexopt":("A regex option", None, "regex", None),
+            "base": ("Long and short base option", None, "store_true", False, 'b'),
+            "longbase": ("Long-only base option", None, "store_true", True),
+            "justatest": ("Another long based option", None, "store_true", True),
+            "store": ("Store option", None, "store", None),
+            "store-with-dash": ("Store option with dash in name", None, "store", None),
+            "store-or-None": ("Store-or-None option", None, "store_or_None", None),
+            "store-or-None-default": ("Store-or-None option with a default", None, "store_or_None", 'somedefault'),
+            "aregexopt": ("A regex option", None, "regex", None),
             }
         descr = ["Base", "Base level of options"]
 
@@ -107,7 +114,7 @@ class TestOption1(GeneralOption):
         self.add_group_parser(self._opts_ext, descr, prefix=prefix)
 
 
-class GeneralOptionTest(TestCase):
+class GeneralOptionTest(EnhancedTestCase):
     """Tests for general option"""
 
     def test_basic(self):
@@ -192,6 +199,8 @@ class GeneralOptionTest(TestCase):
                           'justatest': True,
                           'level_longlevel': True,
                           'store_with_dash':None,
+                          'store_or_None':None,
+                          'store_or_None_default':None,
                           'level_prefix_and_dash':'YY',  # this dict is about destinations
                           'ignoreconfigfiles': None,
                           'configfiles': ['/not/a/real/configfile'],
@@ -601,6 +610,29 @@ debug=1
         self.assertEqual(inst1.configfiles, expected);
         self.assertEqual(inst2.configfiles, expected);
 
+    def test_configfile_reset_None(self):
+        """Test (re)setting of None values in a configuration file."""
+        cfgfile = '\n'.join([
+            '[base]',
+            'base = True',
+            'store',
+            'store-with-dash = foo',
+            'store-or-None',
+            'store-or-None-default',
+        ])
+        tmp1 = NamedTemporaryFile()
+        tmp1.write(cfgfile)
+        tmp1.flush()  # flush, otherwise empty
+
+        if LooseVersion(sys.version) >= LooseVersion('2.7'):
+            topt = TestOption1(go_configfiles=[tmp1.name], go_args=[])
+            self.assertTrue(topt.options.base)
+            self.assertEqual(topt.options.store, None)
+            self.assertEqual(topt.options.store_with_dash, 'foo')
+            self.assertEqual(topt.options.store_or_None, None)
+            self.assertEqual(topt.options.store_or_None_default, None)
+        else:
+            self.assertErrorRegex(ParsingError, '.*', TestOption1, go_configfiles=[tmp1.name], go_args=[])
 
 def suite():
     """ returns all the testcases in this module """


### PR DESCRIPTION
I need this in order to make the EasyBuild framework unit tests robust against any user configuration files that are present (which will be part of https://github.com/hpcugent/easybuild-framework/pull/1167)