### PR TITLE
check for non-empty list of formatting args

### DIFF
--- a/lib/vsc/utils/exceptions.py
+++ b/lib/vsc/utils/exceptions.py
@@ -78,7 +78,8 @@ class LoggedException(Exception):
         @param logger: logger to use
         """
         # format message with (optional) list of formatting arguments
-        msg = msg % args
+        if args:
+            msg = msg % args
 
         logger = kwargs.get('logger', None)
         # try to use logger defined in caller's environment

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ shared_setup.SHARED_TARGET.update({
 
 PACKAGE = {
     'name': 'vsc-base',
-    'version': '2.1.0',
+    'version': '2.1.1',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     'packages': ['vsc', 'vsc.utils', 'vsc.install'],

--- a/test/exceptions.py
+++ b/test/exceptions.py
@@ -68,6 +68,10 @@ class ExceptionsTest(EnhancedTestCase):
         # test formatting of message
         self.assertErrorRegex(LoggedException, 'BOOMBAF', raise_loggedexception, 'BOOM%s', 'BAF')
 
+        # test log message that contains '%s' without any formatting arguments being passed
+        # test formatting of message
+        self.assertErrorRegex(LoggedException, "BOOM '%s'", raise_loggedexception, "BOOM '%s'")
+
         os.remove(tmplog)
 
     def test_loggedexception_specifiedlogger(self):


### PR DESCRIPTION
This fixes a problem like:

```
Traceback (most recent call last):
  File "test/exceptions.py", line 73, in test_loggedexception_defaultlogger
    self.assertErrorRegex(LoggedException, "BOOM '%s'", raise_loggedexception, "BOOM '%s'")
  File "/Users/kehoste/work/vsc-base/lib/vsc/utils/testing.py", line 76, in assertErrorRegex
    call(*args, **kwargs)
  File "test/exceptions.py", line 45, in raise_loggedexception
    raise LoggedException(msg, *args, **kwargs)
  File "/Users/kehoste/work/vsc-base/lib/vsc/utils/exceptions.py", line 81, in __init__
    msg = msg % args
TypeError: not enough arguments for format string
```

Not just a theoretic example, it can occur when reporting syntax errors in easyblocks, for example:

```
$ python -m test.framework.scripts
Couldn't import dot_parser, loading of dot files will not be possible.
.cmd "python /Users/kehoste/work/easybuild-framework/easybuild/scripts/generate_software_list.py --local --quiet --path /var/folders/8s/_frgh9sj6m744mxt5w5lyztr0000gn/T/tmp3gTCVW" exited with exitcode 1 and output:
Couldn't import dot_parser, loading of dot files will not be possible.
Failed to obtain class for None easyblock (not available?): invalid syntax (gcc.py, line 256)
faulty easyconfig /var/folders/8s/_frgh9sj6m744mxt5w5lyztr0000gn/T/tmp3gTCVW/GCC-4.6.3.eb: 'Failed to obtain class for None easyblock (not available?): invalid syntax (gcc.py, line 256)'
Traceback (most recent call last):
  File "/Users/kehoste/work/easybuild-framework/easybuild/scripts/generate_software_list.py", line 139, in <module>
    raise EasyBuildError("faulty easyconfig %s: %s", ec_file, err)
easybuild.tools.build_log.EasyBuildError: "faulty easyconfig /var/folders/8s/_frgh9sj6m744mxt5w5lyztr0000gn/T/tmp3gTCVW/GCC-4.6.3.eb: 'Failed to obtain class for None easyblock (not available?): invalid syntax (gcc.py, line 256)'"

E
======================================================================
ERROR: test_generate_software_list (__main__.ScriptsTest)
Test for generate_software_list.py script.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kehoste/work/easybuild-framework/test/framework/scripts.py", line 68, in test_generate_software_list
    out, ec = run_cmd(cmd, simple=False)
  File "easybuild/tools/run.py", line 80, in inner
    return func(cmd, *args, **kwargs)
  File "easybuild/tools/run.py", line 153, in run_cmd
    return parse_cmd_output(cmd, stdouterr, ec, simple, log_all, log_ok, regexp)
  File "easybuild/tools/run.py", line 384, in parse_cmd_output
    raise EasyBuildError('cmd "%s" exited with exitcode %s and output:\n%s', cmd, ec, stdouterr)
  File "easybuild/tools/build_log.py", line 68, in __init__
    LoggedException.__init__(self, msg)
  File "/Users/kehoste/work/vsc-base/lib/vsc/utils/exceptions.py", line 81, in __init__
    msg = msg % args
TypeError: not enough arguments for format string
```