### PR TITLE
make sure that full path to location has a leading / in LoggedException log message

### DIFF
--- a/lib/vsc/utils/exceptions.py
+++ b/lib/vsc/utils/exceptions.py
@@ -98,6 +98,8 @@ class LoggedException(Exception):
             # determine short location of Python module where error was raised from,
             # i.e. starting with an entry from LOC_INFO_TOP_PKG_NAMES
             path_parts = frameinfo[1].split(os.path.sep)
+            if path_parts[0] == '':
+                path_parts[0] = os.path.sep
             top_indices = [path_parts.index(n) for n in self.LOC_INFO_TOP_PKG_NAMES if n in path_parts]
             relpath = os.path.join(*path_parts[max(top_indices or [0]):])
 

--- a/test/exceptions.py
+++ b/test/exceptions.py
@@ -139,21 +139,37 @@ class ExceptionsTest(EnhancedTestCase):
         self.assertErrorRegex(LoggedException, 'BOOM', raise_testexception, 'BOOM')
         logToFile(tmplog, enable=False)
 
-        log_re = re.compile("^%s :: BOOM$" % getRootLoggerName(), re.M)
+        rootlogname = getRootLoggerName()
+
+        log_re = re.compile("^%s :: BOOM$" % rootlogname, re.M)
         logtxt = open(tmplog, 'r').read()
         self.assertTrue(log_re.match(logtxt), "%s matches %s" % (log_re.pattern, logtxt))
 
         f = open(tmplog, 'w')
         f.write('')
         f.close()
-        TestException.LOC_INFO_TOP_PKG_NAMES = ['vsc']
 
         # location is included if LOC_INFO_TOP_PKG_NAMES is defined
+        TestException.LOC_INFO_TOP_PKG_NAMES = ['vsc']
         logToFile(tmplog, enable=True)
         self.assertErrorRegex(LoggedException, 'BOOM', raise_testexception, 'BOOM')
         logToFile(tmplog, enable=False)
 
-        log_re = re.compile("^%s :: BOOM \(at vsc/utils/testing.py:[0-9]+ in assertErrorRegex\)$" % getRootLoggerName())
+        log_re = re.compile(r"^%s :: BOOM \(at vsc/utils/testing.py:[0-9]+ in assertErrorRegex\)$" % rootlogname)
+        logtxt = open(tmplog, 'r').read()
+        self.assertTrue(log_re.match(logtxt), "%s matches %s" % (log_re.pattern, logtxt))
+
+        f = open(tmplog, 'w')
+        f.write('')
+        f.close()
+
+        # absolute path of location is included if there's no match in LOC_INFO_TOP_PKG_NAMES
+        TestException.LOC_INFO_TOP_PKG_NAMES = ['foobar']
+        logToFile(tmplog, enable=True)
+        self.assertErrorRegex(LoggedException, 'BOOM', raise_testexception, 'BOOM')
+        logToFile(tmplog, enable=False)
+
+        log_re = re.compile(r"^%s :: BOOM \(at /.*/vsc/utils/testing.py:[0-9]+ in assertErrorRegex\)$" % rootlogname)
         logtxt = open(tmplog, 'r').read()
         self.assertTrue(log_re.match(logtxt), "%s matches %s" % (log_re.pattern, logtxt))
 


### PR DESCRIPTION
fix for issue caused by this (stupid, imho) behaviour:

```
>>> os.path.join(*'/home/kehoste/foo'.split(os.path.sep))
'home/kehoste/foo'
```