### PR TITLE
bump version to 2.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ shared_setup.SHARED_TARGET.update({
 
 PACKAGE = {
     'name': 'vsc-base',
-    'version': '2.1.2',
+    'version': '2.2.0',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     'packages': ['vsc', 'vsc.utils', 'vsc.install'],


### PR DESCRIPTION
required because #165 was merged, and https://github.com/hpcugent/easybuild-framework/pull/1249 required the bump vsc-base version