### PR TITLE
bump version to 2.1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ shared_setup.SHARED_TARGET.update({
 
 PACKAGE = {
     'name': 'vsc-base',
-    'version': '2.1.2',
+    'version': '2.1.3',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     'packages': ['vsc', 'vsc.utils', 'vsc.install'],


### PR DESCRIPTION
version bump is required because #165 was merged, and hpcugent/easybuild-framework#1249 requires a newer vsc-base version