### PR TITLE
improve fancylogger performance significantly via caching inspect.getsourcefile and getRootLogger

### DIFF
--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -73,6 +73,19 @@ Logging to a udp server:
 """
 
 import inspect
+
+# patch inspect.getsourcefile to cache results to avoid tons of stat syscalls
+_cachegetsourcefile = {}
+_orig_inspect_getsourcefile = inspect.getsourcefile
+def cached_getsourcefile(obj):
+    """Faster version of inspect.getsourcefile, by caching results."""
+    fn = inspect.getfile(obj)
+    if not fn in _cachegetsourcefile:
+        _cachegetsourcefile[fn] = _orig_inspect_getsourcefile(obj)
+    return _cachegetsourcefile[fn]
+
+inspect.getsourcefile = cached_getsourcefile
+
 import logging
 import logging.handlers
 import os

--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -100,6 +100,7 @@ TEST_LOGGING_FORMAT = '%(levelname)-10s %(name)-15s %(threadName)-10s  %(message
 DEFAULT_LOGGING_FORMAT = '%(asctime)-15s ' + TEST_LOGGING_FORMAT
 FANCYLOG_LOGGING_FORMAT = None
 FANCYLOG_FANCYRECORD = None
+ROOT_LOGGER_NAME = None
 
 # DEFAULT_LOGGING_FORMAT= '%(asctime)-15s %(levelname)-10s %(module)-15s %(threadName)-10s %(message)s'
 MAX_BYTES = 100 * 1024 * 1024  # max bytes in a file with rotating file handler
@@ -421,10 +422,13 @@ def getRootLoggerName():
     returns the name of the root module
     this is the module that is actually running everything and so doing the logging
     """
-    try:
-        return inspect.stack()[-1][1].split('/')[-1].split('.')[0]
-    except Exception:
-        return "?"
+    global ROOT_LOGGER_NAME
+    if ROOT_LOGGER_NAME is None:
+        try:
+            ROOT_LOGGER_NAME = inspect.stack()[-1][1].split('/')[-1].split('.')[0]
+        except Exception:
+            ROOT_LOGGER_NAME = "?"
+    return ROOT_LOGGER_NAME
 
 
 def logToScreen(enable=True, handler=None, name=None, stdout=False):


### PR DESCRIPTION
Opening this PR as is so we don't forget about it, may need some further tweaking to make the caching optional for example.

This yields quite significant performance improvements.

To give some idea: the full EasyBuild framework test suite runs in ~780s with this in place, while it requires 1150s without (on my laptop on an SSD).

Using `python -m cProfile`, I can see:

* a drop in the number of `posix.stat` calls from 8.5M to 218K, i.e. ~40x less (the number of `posix.lstat` calls remained stable), thanks to the monkey-patched `inspect.getsourcefile`
* a drop in the number of `inspect.ismodule` calls from a whopping 410M to 900K, i.e. ~450x less, thanks to the caching of `getRootLogger()`

With the patch applied, most time is now spent on ~15K `select.select` calls (which is basically I/O wait stuff, see https://docs.python.org/2/library/select.html.

@stdweird, @JensTimmerman: please review