### PR TITLE
Support zipped egg installations of vsc-base

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ PACKAGE = {
     'packages': ['vsc', 'vsc.utils', 'vsc.install'],
     'scripts': ['bin/logdaemon.py', 'bin/startlogdaemon.sh', 'bin/bdist_rpm.sh', 'bin/optcomplete.bash'],
     'install_requires' : ['setuptools'],
+    'zip_safe': True,
 }
 
 if __name__ == '__main__':


### PR DESCRIPTION
One issue we find when running jobs on shared file systems is that the startup of processes takes a long time, mostly due to python hitting the file system quite aggressively. @boegel would like to try this out on the EasyBuild test suite and I'd like to support zipped egg installations in hod.

It turns out that vsc-base was happy to be installed as a zipped egg with only a modification to `modules_in_pkg_path`. It's pretty hairy, so I imagine there will be some useful feedback.