### PR TITLE
Remove unused functions 'avail_subclasses_in' and 'modules_in_pkg_path'

### DIFF
--- a/lib/vsc/utils/missing.py
+++ b/lib/vsc/utils/missing.py
@@ -40,11 +40,8 @@ Various functions that are missing from the default Python library.
 @author: Andy Georges (Ghent University)
 @author: Stijn De Weirdt (Ghent University)
 """
-import os
-import re
 import shlex
 import subprocess
-import sys
 import time
 
 from vsc.utils import fancylogger
@@ -330,68 +327,6 @@ def get_subclasses_dict(klass, include_base_class=False):
 def get_subclasses(klass, include_base_class=False):
     """Get list of all subclasses, recursively from the specified base class."""
     return get_subclasses_dict(klass, include_base_class=include_base_class).keys()
-
-
-def modules_in_pkg_path(pkg_path):
-    """Return list of module files in specified package path."""
-    # if the specified (relative) package path doesn't exist, try and determine the absolute path via sys.path
-    if not os.path.isabs(pkg_path) and not os.path.isdir(pkg_path):
-        _log.debug("Obtained non-existing relative package path '%s', will try to figure out absolute path" % pkg_path)
-        newpath = None
-        for sys_path_dir in sys.path:
-            abspath = os.path.join(sys_path_dir, pkg_path)
-            if os.path.isdir(abspath):
-                _log.debug("Found absolute path %s for package path %s, verifying it" % (abspath, pkg_path))
-                # also make sure an __init__.py is in place in every subdirectory
-                is_pkg = True
-                subdir = ''
-                for pkg_path_dir in pkg_path.split(os.path.sep):
-                    subdir = os.path.join(subdir, pkg_path_dir)
-                    if not os.path.isfile(os.path.join(sys_path_dir, subdir, '__init__.py')):
-                        is_pkg = False
-                        tup = (subdir, abspath, pkg_path)
-                        _log.debug("No __init__.py found in %s, %s is not a valid absolute path for pkg_path %s" % tup)
-                        break
-                if is_pkg:
-                    newpath = abspath
-                    break
-
-        if newpath is None:
-            # give up if we couldn't find an absolute path for the imported package
-            tup = (pkg_path, sys.path)
-            raise OSError("Can't browse package via non-existing relative path '%s', not found in sys.path (%s)" % tup)
-        else:
-            pkg_path = newpath
-            _log.debug("Found absolute package path %s" % pkg_path)
-
-    module_regexp = re.compile(r"^(?P<modname>[^_].*|__init__)\.py$")
-    modules = [res.group('modname') for res in map(module_regexp.match, os.listdir(pkg_path)) if res]
-    _log.debug("List of modules for package in %s: %s" % (pkg_path, modules))
-    return modules
-
-
-def avail_subclasses_in(base_class, pkg_name, include_base_class=False):
-    """Determine subclasses for specificied base classes in modules in (only) specified packages."""
-
-    def try_import(name):
-        """Try import the specified package/module."""
-        try:
-            # don't use return value of __import__ since it may not be the package itself but it's parent
-            __import__(name, globals())
-            return sys.modules[name]
-        except ImportError, err:
-            raise ImportError("avail_subclasses_in: failed to import %s: %s" % (name, err))
-
-    # import all modules in package path(s) before determining subclasses
-    pkg = try_import(pkg_name)
-    for pkg_path in pkg.__path__:
-        for mod in modules_in_pkg_path(pkg_path):
-            # no need to directly import __init__ (already done by importing package)
-            if not mod.startswith('__init__'):
-                _log.debug("Importing module '%s' from package '%s'" % (mod, pkg_name))
-                try_import('%s.%s' % (pkg_name, mod))
-
-    return get_subclasses_dict(base_class, include_base_class=include_base_class)
 
 
 class TryOrFail(object):

--- a/test/missing.py
+++ b/test/missing.py
@@ -39,7 +39,7 @@ from random import randint, seed
 from unittest import TestLoader, main
 
 from vsc.utils.fancylogger import setLogLevelDebug, logToScreen
-from vsc.utils.missing import avail_subclasses_in, get_class_for, get_subclasses, get_subclasses_dict, modules_in_pkg_path
+from vsc.utils.missing import get_class_for, get_subclasses, get_subclasses_dict
 from vsc.utils.missing import nub, topological_sort, FrozenDictKnownKeys, TryOrFail
 from vsc.utils.testing import EnhancedTestCase
 
@@ -269,41 +269,6 @@ class TestMissing(EnhancedTestCase):
         self.assertErrorRegex(ImportError, 'No module named .*', get_class_for, 'no.such.module', 'Test')
         self.assertErrorRegex(ImportError, 'Failed to import .*', get_class_for, 'vsc.utils', 'NoSuchClass')
 
-    def test_modules_in_pkg_path(self):
-        """Test modules_in_pkg_path function."""
-        # real example
-        import vsc.utils
-        vsc_utils_modules = ['__init__', 'affinity', 'asyncprocess', 'daemon', 'dateandtime', 'docs',
-                             'exceptions', 'fancylogger', 'frozendict', 'generaloption', 'mail', 'missing',
-                             'optcomplete', 'patterns', 'rest', 'run', 'testing', 'wrapper']
-        self.assertEqual(sorted(modules_in_pkg_path(vsc.utils.__path__[0])), vsc_utils_modules)
-        self.assertEqual(sorted(modules_in_pkg_path('vsc/utils')), vsc_utils_modules)
-
-        # toy testcase
-        testpkg = 'thisisjustatestpkg'
-        tmpdir = tempfile.mkdtemp()
-        os.mkdir(os.path.join(tmpdir, testpkg))
-        for pyfile in ['__init__.py', 'testmod.py', '_hiddenmod.py']:
-            f = open(os.path.join(tmpdir, testpkg, pyfile), 'w')
-            f.write('')  # just empty files
-            f.close()
-
-        # doesn't work via relative package path when not in sys.path
-        msg_regex = "Can't browse package via non-existing relative path '%s', not found in sys.path" % testpkg
-        self.assertErrorRegex(OSError, msg_regex, modules_in_pkg_path, testpkg)
-        # works fine via absolute path to package directory
-        self.assertEqual(sorted(modules_in_pkg_path(os.path.join(tmpdir, testpkg))), ['__init__', 'testmod'])
-        # also found via relative path when parent path is in sys.path
-        sys.path.append(tmpdir)
-        self.assertEqual(sorted(modules_in_pkg_path(testpkg)), ['__init__', 'testmod'])
-        # subdirectories with a missing __init__.py are not considered package
-        os.remove(os.path.join(tmpdir, testpkg, '__init__.py'))
-        self.assertErrorRegex(OSError, msg_regex, modules_in_pkg_path, testpkg)
-
-        # cleanup
-        sys.path = sys.path[:-1]
-        shutil.rmtree(tmpdir)
-
     def test_get_subclasses(self):
         """Test get_subclasses functions."""
         # T1
@@ -335,37 +300,6 @@ class TestMissing(EnhancedTestCase):
         self.assertEqual(sorted(get_subclasses(T1)), sorted([T12, T123, T13]))
         self.assertEqual(sorted(get_subclasses(T1, include_base_class=True)), sorted([T1, T12, T123, T13]))
 
-    def test_avail_subclasses_in(self):
-        """Test avail_subclasses_in function."""
-        orig_sys_path = sys.path[:]
-        sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'sandbox'))
-
-        # companion testmodulebis is purposely not imported
-        from testpkg.testmodule import TestModA, TestModA1, TestModA2
-
-        subclasses = avail_subclasses_in(TestModA, 'testpkg')
-        # verify whether all subclasses are found (not including base class itself, by default)
-        test_subclass_names = ['TestModA1', 'TestModA1B', 'TestModA1B1', 'TestModA2', 'TestModA3']
-        self.assertEqual(sorted([x.__name__ for x in subclasses]), test_subclass_names)
-
-        # verify (direct) subclasses for one of the subclasses of the original base class
-        self.assertEqual(sorted([x.__name__ for x in subclasses[TestModA1]]), ['TestModA1B'])
-
-        # check subclasses for class without subclasses
-        self.assertEqual(sorted([x.__name__ for x in subclasses[TestModA2]]), [])
-
-        # check include_base_classes named argument
-        subclasses = avail_subclasses_in(TestModA, 'testpkg', include_base_class=True)
-        self.assertEqual(sorted([x.__name__ for x in subclasses]), ['TestModA'] + test_subclass_names)
-
-        # verify (direct) subclasses for one of the subclasses of the original base class
-        self.assertEqual(sorted([x.__name__ for x in subclasses[TestModA1]]), ['TestModA1B'])
-
-        # check subclasses for class without subclasses
-        self.assertEqual(sorted([x.__name__ for x in subclasses[TestModA2]]), [])
-
-        # cleanup
-        sys.path = orig_sys_path
 
 def suite():
     """ return all the tests"""


### PR DESCRIPTION
We couldn't find across our public and private githubs where these functions are used, so I'm offering this PR to remove them.