### PR TITLE
support using 'inspect' when desired in LoggedException

### DIFF
--- a/lib/vsc/utils/exceptions.py
+++ b/lib/vsc/utils/exceptions.py
@@ -82,7 +82,10 @@ class LoggedException(Exception):
         @param msg: exception message
         @param *args: list of formatting arguments for exception message
         @param logger: logger to use
+        @param include_location: include location where error was raised from
         """
+        include_location = kwargs.get('include_location', False)
+
         # format message with (optional) list of formatting arguments
         if args:
             msg = msg % args
@@ -94,7 +97,7 @@ class LoggedException(Exception):
                 # move a level up when this instance is derived from LoggedException
                 frames_up += 1
 
-            if __debug__:
+            if include_location or __debug__:
                 # figure out where error was raised from
                 # current frame: this constructor, one frame above: location where LoggedException was created/raised
                 frameinfo = inspect.getouterframes(inspect.currentframe())[frames_up]

--- a/lib/vsc/utils/exceptions.py
+++ b/lib/vsc/utils/exceptions.py
@@ -35,13 +35,13 @@ import os
 from vsc.utils import fancylogger
 
 
-def get_callers_logger(use_inspect=False):
+def get_callers_logger():
     """
     Get logger defined in caller's environment
     @return: logger instance (or None if none was found)
     """
     logger_cls = logging.getLoggerClass()
-    if use_inspect or __debug__:
+    if __debug__:
         frame = inspect.currentframe()
     else:
         frame = None
@@ -75,8 +75,8 @@ class LoggedException(Exception):
     LOGGING_METHOD_NAME = 'error'
     # list of top-level package names to use to format location info; None implies not to include location info
     LOC_INFO_TOP_PKG_NAMES = []
-    # include location where error was raised from
-    INCLUDE_LOCATION = False
+    # include location where error was raised from (enabled by default under 'python', disabled under 'python -O')
+    INCLUDE_LOCATION = __debug__
 
     def __init__(self, msg, *args, **kwargs):
         """
@@ -96,7 +96,7 @@ class LoggedException(Exception):
                 # move a level up when this instance is derived from LoggedException
                 frames_up += 1
 
-            if self.INCLUDE_LOCATION or __debug__:
+            if self.INCLUDE_LOCATION:
                 # figure out where error was raised from
                 # current frame: this constructor, one frame above: location where LoggedException was created/raised
                 frameinfo = inspect.getouterframes(inspect.currentframe())[frames_up]

--- a/lib/vsc/utils/exceptions.py
+++ b/lib/vsc/utils/exceptions.py
@@ -35,13 +35,13 @@ import os
 from vsc.utils import fancylogger
 
 
-def get_callers_logger():
+def get_callers_logger(use_inspect=False):
     """
     Get logger defined in caller's environment
     @return: logger instance (or None if none was found)
     """
     logger_cls = logging.getLoggerClass()
-    if __debug__:
+    if use_inspect or __debug__:
         frame = inspect.currentframe()
     else:
         frame = None

--- a/lib/vsc/utils/exceptions.py
+++ b/lib/vsc/utils/exceptions.py
@@ -75,6 +75,8 @@ class LoggedException(Exception):
     LOGGING_METHOD_NAME = 'error'
     # list of top-level package names to use to format location info; None implies not to include location info
     LOC_INFO_TOP_PKG_NAMES = []
+    # include location where error was raised from
+    INCLUDE_LOCATION = False
 
     def __init__(self, msg, *args, **kwargs):
         """
@@ -82,10 +84,7 @@ class LoggedException(Exception):
         @param msg: exception message
         @param *args: list of formatting arguments for exception message
         @param logger: logger to use
-        @param include_location: include location where error was raised from
         """
-        include_location = kwargs.get('include_location', False)
-
         # format message with (optional) list of formatting arguments
         if args:
             msg = msg % args
@@ -97,7 +96,7 @@ class LoggedException(Exception):
                 # move a level up when this instance is derived from LoggedException
                 frames_up += 1
 
-            if include_location or __debug__:
+            if self.INCLUDE_LOCATION or __debug__:
                 # figure out where error was raised from
                 # current frame: this constructor, one frame above: location where LoggedException was created/raised
                 frameinfo = inspect.getouterframes(inspect.currentframe())[frames_up]

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ shared_setup.SHARED_TARGET.update({
 
 PACKAGE = {
     'name': 'vsc-base',
-    'version': '2.2.5',
+    'version': '2.2.6',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     'packages': ['vsc', 'vsc.utils', 'vsc.install'],

--- a/test/exceptions.py
+++ b/test/exceptions.py
@@ -123,6 +123,7 @@ class ExceptionsTest(EnhancedTestCase):
         """Test inclusion of location information in log message for LoggedException."""
         class TestException(LoggedException):
             LOC_INFO_TOP_PKG_NAMES = None
+            INCLUDE_LOCATION = True
 
         def raise_testexception(msg, *args, **kwargs):
             """Utility function: just raise a TestException."""
@@ -136,7 +137,7 @@ class ExceptionsTest(EnhancedTestCase):
 
         # no location with default LOC_INFO_TOP_PKG_NAMES ([])
         logToFile(tmplog, enable=True)
-        self.assertErrorRegex(LoggedException, 'BOOM', raise_testexception, 'BOOM', include_location=True)
+        self.assertErrorRegex(LoggedException, 'BOOM', raise_testexception, 'BOOM')
         logToFile(tmplog, enable=False)
 
         rootlogname = getRootLoggerName()
@@ -152,7 +153,7 @@ class ExceptionsTest(EnhancedTestCase):
         # location is included if LOC_INFO_TOP_PKG_NAMES is defined
         TestException.LOC_INFO_TOP_PKG_NAMES = ['vsc']
         logToFile(tmplog, enable=True)
-        self.assertErrorRegex(LoggedException, 'BOOM', raise_testexception, 'BOOM', include_location=True)
+        self.assertErrorRegex(LoggedException, 'BOOM', raise_testexception, 'BOOM')
         logToFile(tmplog, enable=False)
 
         log_re = re.compile(r"^%s :: BOOM \(at vsc/utils/testing.py:[0-9]+ in assertErrorRegex\)$" % rootlogname)
@@ -166,7 +167,7 @@ class ExceptionsTest(EnhancedTestCase):
         # absolute path of location is included if there's no match in LOC_INFO_TOP_PKG_NAMES
         TestException.LOC_INFO_TOP_PKG_NAMES = ['foobar']
         logToFile(tmplog, enable=True)
-        self.assertErrorRegex(LoggedException, 'BOOM', raise_testexception, 'BOOM', include_location=True)
+        self.assertErrorRegex(LoggedException, 'BOOM', raise_testexception, 'BOOM')
         logToFile(tmplog, enable=False)
 
         log_re = re.compile(r"^%s :: BOOM \(at /.*/vsc/utils/testing.py:[0-9]+ in assertErrorRegex\)$" % rootlogname)

--- a/test/exceptions.py
+++ b/test/exceptions.py
@@ -183,25 +183,23 @@ class ExceptionsTest(EnhancedTestCase):
 
         # find defined logger in caller's context
         logger = getLogger('foo')
-        callers_logger = get_callers_logger(use_inspect=False)
+        callers_logger = get_callers_logger()
         # result depends on whether tests were run under 'python' or 'python -O'
         self.assertTrue(callers_logger in [logger, None])
-        callers_logger = get_callers_logger(use_inspect=True)
-        self.assertEqual(callers_logger, logger)
 
         # also works when logger is 'higher up'
         class Test(object):
             """Dummy test class"""
             def foo(self, logger=None):
                 """Dummy test method, returns logger from calling context."""
-                return get_callers_logger(use_inspect=True)
+                return get_callers_logger()
 
         test = Test()
-        self.assertEqual(logger, test.foo())
+        self.assertTrue(logger, [test.foo(), None])
 
         # closest logger to caller is preferred
         logger2 = getLogger(test.__class__.__name__)
-        self.assertEqual(logger2, test.foo(logger=logger2))
+        self.assertTrue(logger2 in [test.foo(logger=logger2), None])
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/exceptions.py
+++ b/test/exceptions.py
@@ -183,7 +183,8 @@ class ExceptionsTest(EnhancedTestCase):
         # find defined logger in caller's context
         logger = getLogger('foo')
         callers_logger = get_callers_logger(use_inspect=False)
-        self.assertEqual(callers_logger, None)
+        # result depends on whether tests were run under 'python' or 'python -O'
+        self.assertTrue(callers_logger in [logger, None])
         callers_logger = get_callers_logger(use_inspect=True)
         self.assertEqual(callers_logger, logger)
 


### PR DESCRIPTION
I need this for https://github.com/hpcugent/easybuild-framework/pull/1357, since I want to make sure that an `EasyBuildException` that gets raised always includes the location where it was raised from.

See also https://github.com/hpcugent/easybuild-framework/pull/1357/files#r39891748 