### PR TITLE
add support to detect ambiguity and likely typos in generaloption

### DIFF
--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -494,6 +494,7 @@ class ExtOptionParser(OptionParser):
         Determine if value is/could be an option passed via the commandline.
         If it is, return the reason why (can be used as message); or return None if it isn't.
 
+        opt is the option flag to which the value is passed;
         index is the index of the value on the commandline (if None, it is determined from orig_rargs and rargs)
 
         The method tests for possible ambiguity on the commandline when the parser
@@ -501,7 +502,7 @@ class ExtOptionParser(OptionParser):
         it is (intended as) an option; --longopt=value is never considered ambiguous, regardless of the value.
         """
         # Values that are/could be options that are passed via
-        # --longopt=value is not a problem.
+        # only --longopt=value is not a problem.
         # When processing the enviroment and/or configfile, we always set
         # --longopt=value, so no issues there either.
 
@@ -515,7 +516,7 @@ class ExtOptionParser(OptionParser):
         except ValueError:
             # no index found for value, so not a stand-alone value
             if opt.startswith('--'):
-                # --longopt=value is unambigouos
+                # only --longopt=value is unambigouos
                 return None
 
         if index is None:

--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -751,7 +751,7 @@ class ExtOptionParser(OptionParser):
 
     def get_env_options(self):
         """Retrieve options from the environment: prefix_longopt.upper()"""
-        if not self.environment_arguments is None:
+        if self.environment_arguments is not None:
             # already done, let's not do this again
             return self.environment_arguments
 

--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -751,6 +751,10 @@ class ExtOptionParser(OptionParser):
 
     def get_env_options(self):
         """Retrieve options from the environment: prefix_longopt.upper()"""
+        if not self.environment_arguments is None:
+            # already done, let's not do this again
+            return self.environment_arguments
+
         self.environment_arguments = []
 
         if not self.process_env_options:

--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -243,7 +243,7 @@ class ExtOption(CompleterOption):
                 else:
                     force_fmt = "%s" % self._short_opts[0]
 
-                errmsg = "Value '%s' is also a valid option, use '%s%s' instead." % (value, force_fmt, value))
+                errmsg = "Value '%s' is also a valid option, use '%s%s' instead." % (value, force_fmt, value)
                 raise OptionValueError(
 
         return Option.process(self, opt, value, values, parser)

--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -223,7 +223,7 @@ class ExtOption(CompleterOption):
                 self.log.raiseException("_set_attrs: unknown store_or %s" % self.store_or, exception=ValueError)
 
     def process(self, opt, value, values, parser):
-        """Handle option-as-value issues befoe continuing as usual"""
+        """Handle option-as-value issues before actually processing option."""
 
         if hasattr(parser, 'orig_rargs') and (value in parser._long_opt or value in parser._short_opt):
             orig_rargs = getattr(parser, 'orig_rargs')
@@ -243,9 +243,8 @@ class ExtOption(CompleterOption):
                 else:
                     force_fmt = "%s" % self._short_opts[0]
 
-                raise OptionValueError("Value '%s' is also a valid option."
-                                       " Use '%s%s' to pass this unambigously." %
-                                       (value, force_fmt, value))
+                errmsg = "Value '%s' is also a valid option, use '%s%s' instead." % (value, force_fmt, value))
+                raise OptionValueError(
 
         return Option.process(self, opt, value, values, parser)
 
@@ -497,7 +496,7 @@ class ExtOptionParser(OptionParser):
 
         self.environment_arguments = None
         self.commandline_arguments = None
-        self.orig_rargs = None # copy of the original arguments
+        self.orig_rargs = None  # copy of the original arguments
 
     def parse_args(self, args=None, values=None):
         """Keep a copy of the original arguments for callback / option processing"""

--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -520,7 +520,7 @@ class ExtOptionParser(OptionParser):
                 return None
 
         if index is None:
-            # index of last parsed arg in orig_rargs via remainder of rargs
+            # index of last parsed arg in commandline_arguments via remainder of rargs
             index = len(self.commandline_arguments) - len(self.rargs) - 1
 
         if cmdline_index is not None and index != cmdline_index:

--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -244,7 +244,7 @@ class ExtOption(CompleterOption):
                     force_fmt = "%s" % self._short_opts[0]
 
                 errmsg = "Value '%s' is also a valid option, use '%s%s' instead." % (value, force_fmt, value)
-                raise OptionValueError(
+                raise OptionValueError(errmsg)
 
         return Option.process(self, opt, value, values, parser)
 

--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -528,8 +528,8 @@ class ExtOptionParser(OptionParser):
             return None
 
         if not self.ALLOW_OPTION_NAME_AS_VALUE:
-            if '-%s' % value in self._short_opt or '-%s' % value in self._long_opt:
-                return "'-%(val)s' is a valid option, so using '%(val)s' as value is likely a typo" % {'val': value}
+            if '-%s' % value in self._short_opt.keys() + self._long_opt.keys():
+                return "'-%s' is a valid option" % value
 
         # First test the exact problem where the value is an option
         if (not self.ALLOW_OPTION_AS_VALUE) and (value in self._long_opt or value in self._short_opt):

--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -504,6 +504,11 @@ class ExtOptionParser(OptionParser):
         # --longopt=value is not a problem.
         # When processing the enviroment and/or configfile, we always set
         # --longopt=value, so no issues there either.
+
+        # following checks assume that value is a string (not a store_or_None)
+        if not isinstance(value, basestring):
+            return None
+
         cmdline_index = None
         try:
             cmdline_index = self.commandline_arguments.index(value)
@@ -529,7 +534,7 @@ class ExtOptionParser(OptionParser):
         if (not self.ALLOW_OPTION_AS_VALUE) and (value in self._long_opt or value in self._short_opt):
             return "Value '%s' is also a valid option" % value
 
-        if not self.ALLOW_DASH_AS_VALUE and value is not None and value.startswith('-'):
+        if not self.ALLOW_DASH_AS_VALUE and value.startswith('-'):
             return "Value '%s' starts with a '-'" % value
 
         if not self.ALLOW_TYPO_AS_VALUE:

--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -528,10 +528,10 @@ class ExtOptionParser(OptionParser):
             return None
 
         if not self.ALLOW_OPTION_NAME_AS_VALUE:
-            if '-%s' % value in self._short_opt.keys() + self._long_opt.keys():
+            value_as_opt = '-%s' % value
+            if value_as_opt in self._short_opt or value_as_opt in self._long_opt:
                 return "'-%s' is a valid option" % value
 
-        # First test the exact problem where the value is an option
         if (not self.ALLOW_OPTION_AS_VALUE) and (value in self._long_opt or value in self._short_opt):
             return "Value '%s' is also a valid option" % value
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ shared_setup.remove_extra_bdist_rpm_files = remove_bdist_rpm_source_file
 
 PACKAGE = {
     'name': 'vsc-base',
-    'version': '2.4.0',
+    'version': '2.4.1',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     'packages': ['vsc', 'vsc.install', 'vsc.utils'],

--- a/test/generaloption.py
+++ b/test/generaloption.py
@@ -764,6 +764,13 @@ debug=1
                               go_args=['--level-level'], envvar_prefix='GENERALOPTIONTEST', error_env_options=True,
                               error_env_option_method=raise_error)
 
+    def test_nosuchoption(self):
+        """Test catching of non-existing options."""
+        self.mock_stderr(True)  # reset
+        self.assertErrorRegex(SystemExit, '.*', TestOption1, go_args=['--nosuchoptiondefinedfoobar'])
+        stderr = self.get_stderr()
+        self.assertTrue("no such option: --nosuchoptiondefinedfoobar" in stderr)
+
     def test_option_as_value(self):
         """Test how valid options being used as values are handled."""
         # -s requires an argument
@@ -799,8 +806,11 @@ debug=1
         stderr = self.get_stderr()
         self.assertTrue("Value '--base' is also a valid option" in stderr)
 
-        # FIXME: this should fail?
-        topt = TestOption1(go_args=['--store', '--nosuchoptiondefinedfoobar'])
+        # including a non-existing option should still result in 'no such option' error
+        self.mock_stderr(True)  # reset
+        self.assertErrorRegex(SystemExit, '.*', TestOption1, go_args=['--store', '--nosuchoptiondefinedfoobar'])
+        stderr = self.get_stderr()
+        self.assertTrue("no such option: --nosuchoptiondefinedfoobar" in stderr)
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/generaloption.py
+++ b/test/generaloption.py
@@ -115,7 +115,7 @@ class TestOption1(GeneralOption):
 class GeneralOptionTest(EnhancedTestCase):
     """Tests for general option"""
 
-    def xtest_help_short(self):
+    def test_help_short(self):
         """Generate short help message"""
         topt = TestOption1(go_args=['-h'],
                            go_nosystemexit=True,  # when printing help, optparse ends with sys.exit
@@ -126,7 +126,7 @@ class GeneralOptionTest(EnhancedTestCase):
         helptxt = topt.parser.help_to_file.getvalue()
         self.assertEqual(helptxt.find("--level-longlevel"), -1, "Long documentation not expanded in short help")
 
-    def xtest_help(self):
+    def test_help(self):
         """Generate (long) help message"""
         topt = TestOption1(go_args=['--help'],
                            go_nosystemexit=True,
@@ -141,7 +141,7 @@ class GeneralOptionTest(EnhancedTestCase):
 
         self.assertTrue(helptxt.find("--level-longlevel") > -1, "Long documentation expanded in long help")
 
-    def xtest_help_long(self):
+    def test_help_long(self):
         """Generate long help message"""
         topt = TestOption1(go_args=['-H'],
                            go_nosystemexit=True,
@@ -153,7 +153,7 @@ class GeneralOptionTest(EnhancedTestCase):
         helptxt = topt.parser.help_to_file.getvalue()
         self.assertTrue(helptxt.find("--level-longlevel") > -1, "Long documentation expanded in long help")
 
-    def xtest_help_outputformats(self):
+    def test_help_outputformats(self):
         """Generate (long) rst help message"""
         for output_format in HELP_OUTPUT_FORMATS:
             topt = TestOption1(go_args=['--help=%s' % output_format],
@@ -170,7 +170,7 @@ class GeneralOptionTest(EnhancedTestCase):
             else:
                 self.assertTrue(helptxt.find("--level-longlevel") > -1, "Long documentation expanded in long help (format: %s)" % output_format)
 
-    def xtest_help_confighelp(self):
+    def test_help_confighelp(self):
         """Generate long help message"""
         topt = TestOption1(go_args=['--confighelp'],
                            go_nosystemexit=True,
@@ -186,13 +186,13 @@ class GeneralOptionTest(EnhancedTestCase):
             self.assertTrue(topt.parser.help_to_file.getvalue().find("#%s" % opt) > -1,
                             "Looking for '#%s' option marker" % opt)
 
-    def xtest_dest_with_dash(self):
+    def test_dest_with_dash(self):
         """Test the renaming of long opts to dest"""
         topt = TestOption1(go_args=['--store-with-dash', 'XX', '--level-prefix-and-dash=YY'])
         self.assertEqual(topt.options.store_with_dash, 'XX')
         self.assertEqual(topt.options.level_prefix_and_dash, 'YY')
 
-    def xtest_quote(self):
+    def test_quote(self):
         """Test quote/unquote"""
         value = 'value with whitespace'
         txt = '--option=%s' % value
@@ -200,7 +200,7 @@ class GeneralOptionTest(EnhancedTestCase):
         self.assertEqual(str(txt), '--option=value with whitespace')
         self.assertEqual(txt , shell_unquote(shell_quote(txt)))
 
-    def xtest_generate_cmdline(self):
+    def test_generate_cmdline(self):
         """Test the creation of cmd_line args to match options"""
         self.maxDiff = None
 
@@ -306,7 +306,7 @@ class GeneralOptionTest(EnhancedTestCase):
         self.assertTrue(topt.options.aregexopt is not None)
         self.assertEqual(topt.options.aregexopt.pattern, "'^foo.*bar$'")
 
-    def xtest_enable_disable(self):
+    def test_enable_disable(self):
         """Test the enable/disable prefix
             longbase is a store_true with default True; with --disable one can set it to False
             level_level : --enable- keeps the defined action
@@ -318,7 +318,7 @@ class GeneralOptionTest(EnhancedTestCase):
 
         self.assertEqual(topt.generate_cmd_line(ignore=ign), ['--level-level', '--disable-longbase'])
 
-    def xtest_ext_date_datetime(self):
+    def test_ext_date_datetime(self):
         """Test date and datetime action"""
         topt = TestOption1(go_args=['--ext-date=1970-01-01'])
         self.assertEqual(topt.options.ext_date , datetime.date(1970, 1, 1))
@@ -329,7 +329,7 @@ class GeneralOptionTest(EnhancedTestCase):
         topt = TestOption1(go_args=['--ext-datetime=1970-01-01 01:01:01.000001'])
         self.assertEqual(topt.options.ext_datetime , datetime.datetime(1970, 1, 1, 1, 1, 1, 1))
 
-    def xtest_ext_add(self):
+    def test_ext_add(self):
         """Test add and add_first action"""
 
         # add to None default
@@ -372,7 +372,7 @@ class GeneralOptionTest(EnhancedTestCase):
             self.assertEqual(topt.options.ext_add_list_flex, val)
             self.assertEqual(topt.generate_cmd_line(ignore=r'(?<!_flex)$'), [cmd])
 
-    def xtest_ext_add_multi(self):
+    def test_ext_add_multi(self):
         """Test behaviour when 'add' options are used multiple times."""
         fd, cfgfile = tempfile.mkstemp()
         os.close(fd)
@@ -455,7 +455,7 @@ class GeneralOptionTest(EnhancedTestCase):
         self.assertEqual(topt.options.ext_add_pathlist_flex, ['seven', 'p2', 'p3', 'eight'])
         del os.environ['TEST_EXT_ADD_PATHLIST_FLEX']
 
-    def xtest_str_list_tuple(self):
+    def test_str_list_tuple(self):
         """Test strlist / strtuple type"""
         # extend to None default
         topt = TestOption1(go_args=['--ext-strlist=two,three',
@@ -468,7 +468,7 @@ class GeneralOptionTest(EnhancedTestCase):
         self.assertEqual(topt.options.ext_pathlist, ['two,three', 'four', 'five'])
         self.assertEqual(topt.options.ext_pathtuple, ('two,three', 'four', 'five',))
 
-    def xtest_store_or_None(self):
+    def test_store_or_None(self):
         """Test store_or_None action"""
         ign = r'^(?!ext_optional)'
         topt = TestOption1(go_args=[], go_nosystemexit=True,)
@@ -497,7 +497,7 @@ class GeneralOptionTest(EnhancedTestCase):
         topt = TestOption1(go_args=['--ext-optionalchoice', 'CHOICE1'], go_nosystemexit=True,)
         self.assertEqual(topt.options.ext_optionalchoice, 'CHOICE1')
 
-    def xtest_configfiles(self):
+    def test_configfiles(self):
         """Test configfiles (base section for empty prefix from auto_section_name)"""
         CONFIGFILE1 = """
 [base]
@@ -603,7 +603,7 @@ store=%(FROMINIT)s
         tmp2.close()
         tmp3.close()
 
-    def xtest_get_options_by_property(self):
+    def test_get_options_by_property(self):
         """Test get_options_by_property and firends like get_options_by_prefix"""
         topt = TestOption1(go_args=['--ext-optional=REALVALUE'], go_nosystemexit=True,)
 
@@ -611,7 +611,7 @@ store=%(FROMINIT)s
         self.assertEqual(len(topt.get_options_by_prefix('ext')), len(topt._opts_ext))
         self.assertEqual(topt.get_options_by_prefix('ext')['optional'], 'REALVALUE')
 
-    def xtest_loglevel(self):
+    def test_loglevel(self):
         """Test the loglevel default setting"""
         topt = TestOption1(go_args=['--ext-optional=REALVALUE'], go_nosystemexit=True,)
         self.assertEqual(topt.log.getEffectiveLevel(), fancylogger.getLevelInt(topt.DEFAULT_LOGLEVEL.upper()))
@@ -665,7 +665,7 @@ debug=1
         del os.environ['%s_INFO' % envvar]
         tmp1.close()
 
-    def xtest_optcomplete(self):
+    def test_optcomplete(self):
         """Test optcomplete support"""
 
         reg_reply = re.compile(r'^COMPREPLY=\((.*)\)$')
@@ -700,7 +700,7 @@ debug=1
         compl_opts = reg_reply.search(out).group(1).split()
         self.assertEqual(compl_opts, ['--debug'])
 
-    def xtest_get_by_prefix(self):
+    def test_get_by_prefix(self):
         """Test dict by prefix"""
         topt = TestOption1(go_args=['--level-level',
                             '--longbase',
@@ -724,7 +724,7 @@ debug=1
         for noprefix_opt in noprefix_opts:
             self.assertTrue(noprefix_opt in dbp)
 
-    def xtest_multiple_init(self):
+    def test_multiple_init(self):
         """Test behaviour when creating multiple instances of same GO class"""
         inst1 = TestOption1(go_args=['--level-level'])
         inst2 = TestOption1(go_args=['--level-level'])
@@ -737,7 +737,7 @@ debug=1
         self.assertEqual(inst1.configfiles, expected)
         self.assertEqual(inst2.configfiles, expected)
 
-    def xtest_error_env_options(self):
+    def test_error_env_options(self):
         """Test log error on unknown environment option"""
         self.reset_logcache()
         mylogger = fancylogger.getLogger('ExtOptionParser')

--- a/test/generaloption.py
+++ b/test/generaloption.py
@@ -55,7 +55,7 @@ class TestOption1(GeneralOption):
             "base":("Long and short base option", None, "store_true", False, 'b'),
             "longbase":("Long-only base option", None, "store_true", True),
             "justatest":("Another long based option", None, "store_true", True),
-            "store":("Store option", None, "store", None),
+            "store":("Store option", None, "store", None, 's'),
             "store-with-dash":("Store option with dash in name", None, "store", None),
             "aregexopt":("A regex option", None, "regex", None),
             }
@@ -115,7 +115,7 @@ class TestOption1(GeneralOption):
 class GeneralOptionTest(EnhancedTestCase):
     """Tests for general option"""
 
-    def test_help_short(self):
+    def xtest_help_short(self):
         """Generate short help message"""
         topt = TestOption1(go_args=['-h'],
                            go_nosystemexit=True,  # when printing help, optparse ends with sys.exit
@@ -126,7 +126,7 @@ class GeneralOptionTest(EnhancedTestCase):
         helptxt = topt.parser.help_to_file.getvalue()
         self.assertEqual(helptxt.find("--level-longlevel"), -1, "Long documentation not expanded in short help")
 
-    def test_help(self):
+    def xtest_help(self):
         """Generate (long) help message"""
         topt = TestOption1(go_args=['--help'],
                            go_nosystemexit=True,
@@ -141,7 +141,7 @@ class GeneralOptionTest(EnhancedTestCase):
 
         self.assertTrue(helptxt.find("--level-longlevel") > -1, "Long documentation expanded in long help")
 
-    def test_help_long(self):
+    def xtest_help_long(self):
         """Generate long help message"""
         topt = TestOption1(go_args=['-H'],
                            go_nosystemexit=True,
@@ -153,7 +153,7 @@ class GeneralOptionTest(EnhancedTestCase):
         helptxt = topt.parser.help_to_file.getvalue()
         self.assertTrue(helptxt.find("--level-longlevel") > -1, "Long documentation expanded in long help")
 
-    def test_help_outputformats(self):
+    def xtest_help_outputformats(self):
         """Generate (long) rst help message"""
         for output_format in HELP_OUTPUT_FORMATS:
             topt = TestOption1(go_args=['--help=%s' % output_format],
@@ -170,7 +170,7 @@ class GeneralOptionTest(EnhancedTestCase):
             else:
                 self.assertTrue(helptxt.find("--level-longlevel") > -1, "Long documentation expanded in long help (format: %s)" % output_format)
 
-    def test_help_confighelp(self):
+    def xtest_help_confighelp(self):
         """Generate long help message"""
         topt = TestOption1(go_args=['--confighelp'],
                            go_nosystemexit=True,
@@ -186,13 +186,13 @@ class GeneralOptionTest(EnhancedTestCase):
             self.assertTrue(topt.parser.help_to_file.getvalue().find("#%s" % opt) > -1,
                             "Looking for '#%s' option marker" % opt)
 
-    def test_dest_with_dash(self):
+    def xtest_dest_with_dash(self):
         """Test the renaming of long opts to dest"""
         topt = TestOption1(go_args=['--store-with-dash', 'XX', '--level-prefix-and-dash=YY'])
         self.assertEqual(topt.options.store_with_dash, 'XX')
         self.assertEqual(topt.options.level_prefix_and_dash, 'YY')
 
-    def test_quote(self):
+    def xtest_quote(self):
         """Test quote/unquote"""
         value = 'value with whitespace'
         txt = '--option=%s' % value
@@ -200,7 +200,7 @@ class GeneralOptionTest(EnhancedTestCase):
         self.assertEqual(str(txt), '--option=value with whitespace')
         self.assertEqual(txt , shell_unquote(shell_quote(txt)))
 
-    def test_generate_cmdline(self):
+    def xtest_generate_cmdline(self):
         """Test the creation of cmd_line args to match options"""
         self.maxDiff = None
 
@@ -306,7 +306,7 @@ class GeneralOptionTest(EnhancedTestCase):
         self.assertTrue(topt.options.aregexopt is not None)
         self.assertEqual(topt.options.aregexopt.pattern, "'^foo.*bar$'")
 
-    def test_enable_disable(self):
+    def xtest_enable_disable(self):
         """Test the enable/disable prefix
             longbase is a store_true with default True; with --disable one can set it to False
             level_level : --enable- keeps the defined action
@@ -318,7 +318,7 @@ class GeneralOptionTest(EnhancedTestCase):
 
         self.assertEqual(topt.generate_cmd_line(ignore=ign), ['--level-level', '--disable-longbase'])
 
-    def test_ext_date_datetime(self):
+    def xtest_ext_date_datetime(self):
         """Test date and datetime action"""
         topt = TestOption1(go_args=['--ext-date=1970-01-01'])
         self.assertEqual(topt.options.ext_date , datetime.date(1970, 1, 1))
@@ -329,7 +329,7 @@ class GeneralOptionTest(EnhancedTestCase):
         topt = TestOption1(go_args=['--ext-datetime=1970-01-01 01:01:01.000001'])
         self.assertEqual(topt.options.ext_datetime , datetime.datetime(1970, 1, 1, 1, 1, 1, 1))
 
-    def test_ext_add(self):
+    def xtest_ext_add(self):
         """Test add and add_first action"""
 
         # add to None default
@@ -372,7 +372,7 @@ class GeneralOptionTest(EnhancedTestCase):
             self.assertEqual(topt.options.ext_add_list_flex, val)
             self.assertEqual(topt.generate_cmd_line(ignore=r'(?<!_flex)$'), [cmd])
 
-    def test_ext_add_multi(self):
+    def xtest_ext_add_multi(self):
         """Test behaviour when 'add' options are used multiple times."""
         fd, cfgfile = tempfile.mkstemp()
         os.close(fd)
@@ -455,7 +455,7 @@ class GeneralOptionTest(EnhancedTestCase):
         self.assertEqual(topt.options.ext_add_pathlist_flex, ['seven', 'p2', 'p3', 'eight'])
         del os.environ['TEST_EXT_ADD_PATHLIST_FLEX']
 
-    def test_str_list_tuple(self):
+    def xtest_str_list_tuple(self):
         """Test strlist / strtuple type"""
         # extend to None default
         topt = TestOption1(go_args=['--ext-strlist=two,three',
@@ -468,7 +468,7 @@ class GeneralOptionTest(EnhancedTestCase):
         self.assertEqual(topt.options.ext_pathlist, ['two,three', 'four', 'five'])
         self.assertEqual(topt.options.ext_pathtuple, ('two,three', 'four', 'five',))
 
-    def test_store_or_None(self):
+    def xtest_store_or_None(self):
         """Test store_or_None action"""
         ign = r'^(?!ext_optional)'
         topt = TestOption1(go_args=[], go_nosystemexit=True,)
@@ -497,7 +497,7 @@ class GeneralOptionTest(EnhancedTestCase):
         topt = TestOption1(go_args=['--ext-optionalchoice', 'CHOICE1'], go_nosystemexit=True,)
         self.assertEqual(topt.options.ext_optionalchoice, 'CHOICE1')
 
-    def test_configfiles(self):
+    def xtest_configfiles(self):
         """Test configfiles (base section for empty prefix from auto_section_name)"""
         CONFIGFILE1 = """
 [base]
@@ -603,7 +603,7 @@ store=%(FROMINIT)s
         tmp2.close()
         tmp3.close()
 
-    def test_get_options_by_property(self):
+    def xtest_get_options_by_property(self):
         """Test get_options_by_property and firends like get_options_by_prefix"""
         topt = TestOption1(go_args=['--ext-optional=REALVALUE'], go_nosystemexit=True,)
 
@@ -611,7 +611,7 @@ store=%(FROMINIT)s
         self.assertEqual(len(topt.get_options_by_prefix('ext')), len(topt._opts_ext))
         self.assertEqual(topt.get_options_by_prefix('ext')['optional'], 'REALVALUE')
 
-    def test_loglevel(self):
+    def xtest_loglevel(self):
         """Test the loglevel default setting"""
         topt = TestOption1(go_args=['--ext-optional=REALVALUE'], go_nosystemexit=True,)
         self.assertEqual(topt.log.getEffectiveLevel(), fancylogger.getLevelInt(topt.DEFAULT_LOGLEVEL.upper()))
@@ -665,7 +665,7 @@ debug=1
         del os.environ['%s_INFO' % envvar]
         tmp1.close()
 
-    def test_optcomplete(self):
+    def xtest_optcomplete(self):
         """Test optcomplete support"""
 
         reg_reply = re.compile(r'^COMPREPLY=\((.*)\)$')
@@ -700,7 +700,7 @@ debug=1
         compl_opts = reg_reply.search(out).group(1).split()
         self.assertEqual(compl_opts, ['--debug'])
 
-    def test_get_by_prefix(self):
+    def xtest_get_by_prefix(self):
         """Test dict by prefix"""
         topt = TestOption1(go_args=['--level-level',
                             '--longbase',
@@ -724,7 +724,7 @@ debug=1
         for noprefix_opt in noprefix_opts:
             self.assertTrue(noprefix_opt in dbp)
 
-    def test_multiple_init(self):
+    def xtest_multiple_init(self):
         """Test behaviour when creating multiple instances of same GO class"""
         inst1 = TestOption1(go_args=['--level-level'])
         inst2 = TestOption1(go_args=['--level-level'])
@@ -737,7 +737,7 @@ debug=1
         self.assertEqual(inst1.configfiles, expected)
         self.assertEqual(inst2.configfiles, expected)
 
-    def test_error_env_options(self):
+    def xtest_error_env_options(self):
         """Test log error on unknown environment option"""
         self.reset_logcache()
         mylogger = fancylogger.getLogger('ExtOptionParser')
@@ -764,6 +764,43 @@ debug=1
                               go_args=['--level-level'], envvar_prefix='GENERALOPTIONTEST', error_env_options=True,
                               error_env_option_method=raise_error)
 
+    def test_option_as_value(self):
+        """Test how valid options being used as values are handled."""
+        # -s requires an argument
+        self.mock_stderr(True)
+        self.assertErrorRegex(SystemExit, '.*', TestOption1, go_args=['-b', '-s'])
+        stderr = self.get_stderr()
+        self.assertTrue("-s option requires an argument" in stderr)
+
+        # valid ways of specifying '-b' as a value to --store/-s
+        topt = TestOption1(go_args=['--store=-b'])
+        self.assertEqual(topt.options.store, '-b')
+        self.assertFalse(topt.options.base)  # remain False (default value)
+
+        topt = TestOption1(go_args=['-s-b'])  # equivalent to --store=-b
+        self.assertEqual(topt.options.store, '-b')
+        self.assertFalse(topt.options.base)  # remain False (default value)
+
+        # -s -b is not a valid list of flags, since it's ambiguous: is '-b' a value for '-s', or an option?
+        self.mock_stderr(True)  # reset
+        self.assertErrorRegex(SystemExit, '.*', TestOption1, go_args=['-s', '-b'])
+        stderr = self.get_stderr()
+        self.assertTrue("Value '-b' is also a valid option" in stderr)
+
+        # same for --store -b
+        self.mock_stderr(True)  # reset
+        self.assertErrorRegex(SystemExit, '.*', TestOption1, go_args=['--store', '-b'])
+        stderr = self.get_stderr()
+        self.assertTrue("Value '-b' is also a valid option" in stderr)
+
+        # same for --store --base
+        self.mock_stderr(True)  # reset
+        self.assertErrorRegex(SystemExit, '.*', TestOption1, go_args=['--store', '--base'])
+        stderr = self.get_stderr()
+        self.assertTrue("Value '--base' is also a valid option" in stderr)
+
+        # FIXME: this should fail?
+        topt = TestOption1(go_args=['--store', '--nosuchoptiondefinedfoobar'])
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/generaloption.py
+++ b/test/generaloption.py
@@ -806,9 +806,15 @@ debug=1
         stderr = self.get_stderr()
         self.assertTrue("Value '--base' is also a valid option" in stderr)
 
-        # including a non-existing option should still result in 'no such option' error
+        # including a non-existing option will result in it being treated as a value
+        topt = TestOption1(go_args=['--store', '-f'])
+        self.assertEqual(topt.options.store, '-f')
+        topt = TestOption1(go_args=['--store', '--foo'])
+        self.assertEqual(topt.options.store, '--foo')
+
+        # non-existing options are still reported if they're not consumed as a value
         self.mock_stderr(True)  # reset
-        self.assertErrorRegex(SystemExit, '.*', TestOption1, go_args=['--store', '--nosuchoptiondefinedfoobar'])
+        self.assertErrorRegex(SystemExit, '.*', TestOption1, go_args=['--store', '--foo', '--nosuchoptiondefinedfoobar'])
         stderr = self.get_stderr()
         self.assertTrue("no such option: --nosuchoptiondefinedfoobar" in stderr)
 

--- a/test/generaloption.py
+++ b/test/generaloption.py
@@ -812,7 +812,7 @@ debug=1
             """Check whether expected failures/success occur with given message template."""
             for idx, value in enumerate(tp.commandline_arguments):
                 msg = tpl % value
-                res = tp.is_value_a_commandline_option(value, index=idx)
+                res = tp.is_value_a_commandline_option('--opt', value, index=idx)
                 if idx in fail:
                     self.assertFalse(res is None, "failure should not return None for value %s" % value)
                     self.assertTrue(msg in res, msg='%s in %s' % (msg, res))

--- a/test/generaloption.py
+++ b/test/generaloption.py
@@ -847,21 +847,29 @@ debug=1
         self._match_testoption1_sysexit(['-b', '-s'],
                                         "-s option requires an argument")
 
-        # valid ways of specifying '-b' as a value to --store/-s
+        # only valid way of specifying '-b' as a value to --store
         topt = TestOption1(go_args=['--store=-b'])
         self.assertEqual(topt.options.store, '-b')
         self.assertFalse(topt.options.base)  # remain False (default value)
 
-        topt = TestOption1(go_args=['-s-b'])  # equivalent to --store=-b (even though -b is a valid short option)
-        self.assertEqual(topt.options.store, '-b')
-        self.assertFalse(topt.options.base)  # remain False (default value)
+        # when -b/--base is an option, the following are not accepted, since they're likely not what intended
+        self._match_testoption1_sysexit(['-sb'],
+                                        "'-b' is a valid option, so using 'b' as value is likely a typo")
+        self._match_testoption1_sysexit(['-s', 'b'],
+                                        "'-b' is a valid option, so using 'b' as value is likely a typo")
+        self._match_testoption1_sysexit(['--store', 'b'],
+                                        "'-b' is a valid option, so using 'b' as value is likely a typo")
+        self._match_testoption1_sysexit(['--store', '-base'],
+                                        "'--base' is a valid option, so using '-base' as value is likely a typo")
+        self._match_testoption1_sysexit(['-s', '-base'],
+                                        "'--base' is a valid option, so using '-base' as value is likely a typo")
+        self._match_testoption1_sysexit(['-s-base'],
+                                        "'--base' is a valid option, so using '-base' as value is likely a typo")
 
-        topt = TestOption1(go_args=['-sb'])  # equivalent to --store=b (even though -b is a valid short option)
-        self.assertEqual(topt.options.store, 'b')
-        self.assertFalse(topt.options.base)  # remain False (default value)
+        #self._match_testoption1_sysexit(['-s-b'],
+        #                                "Value '-b' is also a valid option")
 
-
-        # -s -b is not a valid list of flags (by default), since it's ambiguous: is '-b' a value for '-s', or an option?
+        # -s -b is not a valid list of flags, since it's ambiguous: is '-b' a value for '-s', or an option?
         self._match_testoption1_sysexit(['-s', '-b'],
                                         "Value '-b' is also a valid option")
 
@@ -869,15 +877,11 @@ debug=1
         self._match_testoption1_sysexit(['--store', '-b'],
                                         "Value '-b' is also a valid option")
 
-        # same for --store=-b
-        self._match_testoption1_sysexit(['--store=-b'],
-                                        "Value '-b' is also a valid option")
-
         # same for --store --base
         self._match_testoption1_sysexit(['--store', '--base'],
                                         "Value '--base' is also a valid option")
 
-        # including a non-existing option will result in it being treated as a value, but is not allowed (by default)
+        # including a non-existing option will result in it being treated as a value, but is not allowed
         self._match_testoption1_sysexit(['--store', '-f'],
                                         "Value '-f' starts with a '-'")
 


### PR DESCRIPTION
wrapper PR for @stdweird's #185 

changes on top include cleanup/enhanced tests and support to also recognise values as likely options (to  reject e.g. `-rf` which is probably meant to be `--robot --force` but is interpreted as `--robot=f`