### PR TITLE
change default value for urltemplate argument in shared_setup.action_target

### DIFF
--- a/lib/vsc/install/shared_setup.py
+++ b/lib/vsc/install/shared_setup.py
@@ -476,7 +476,7 @@ def build_setup_cfg_for_bdist_rpm(target):
     setup_cfg.close()
 
 
-def action_target(target, setupfn=setup, extra_sdist=[], urltemplate=None):
+def action_target(target, setupfn=setup, extra_sdist=[], urltemplate=URL_GH_HPCUGENT):
     # EXTRA_SDIST_FILES.extend(extra_sdist)
 
     do_cleanup = True

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib
 
 
 import vsc.install.shared_setup as shared_setup
-from vsc.install.shared_setup import ag, kh, jt, sdw, URL_GH_HPCUGENT
+from vsc.install.shared_setup import ag, kh, jt, sdw
 
 def remove_bdist_rpm_source_file():
     """List of files to remove from the (source) RPM."""
@@ -56,7 +56,7 @@ shared_setup.RELOAD_VSC_MODS = True
 
 PACKAGE = {
     'name': 'vsc-base',
-    'version': '2.4.2',
+    'version': '2.4.4',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     'packages': ['vsc', 'vsc.install', 'vsc.utils'],
@@ -66,4 +66,4 @@ PACKAGE = {
 }
 
 if __name__ == '__main__':
-    shared_setup.action_target(PACKAGE, urltemplate=URL_GH_HPCUGENT)
+    shared_setup.action_target(PACKAGE)


### PR DESCRIPTION
This helps around dancing around a problem where installing the latest vsc-base while having an older vsc-base installation with `easy_install`, see below.

Once we flesh out vsc-install, this should be a non-issue (not 100% sure).

```
Traceback (most recent call last):
  File "/usr/bin/easy_install", line 9, in <module>
    load_entry_point('distribute==0.6.10', 'console_scripts', 'easy_install')()
  File "/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py", line 1715, in main
    with_ei_usage(lambda:
  File "/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py", line 1696, in with_ei_usage
    return f()
  File "/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py", line 1719, in <lambda>
    distclass=DistributionWithoutHelpCommands, **kw
  File "/usr/lib64/python2.6/distutils/core.py", line 152, in setup
    dist.run_commands()
  File "/usr/lib64/python2.6/distutils/dist.py", line 975, in run_commands
    self.run_command(cmd)
  File "/usr/lib64/python2.6/distutils/dist.py", line 995, in run_command
    cmd_obj.run()
  File "/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py", line 236, in run
    self.easy_install(spec, not self.no_deps)
  File "/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py", line 447, in easy_install
    return self.install_item(None, download, tmpdir, deps, True)
  File "/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py", line 502, in install_item
    dists = self.install_eggs(spec, download, tmpdir)
  File "/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py", line 681, in install_eggs
    return self.build_and_install(setup_script, setup_base)
  File "/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py", line 958, in build_and_install
    self.run_setup(setup_script, setup_base, args)
  File "/usr/lib/python2.6/site-packages/setuptools/command/easy_install.py", line 947, in run_setup
    run_setup(setup_script, args)
  File "/usr/lib/python2.6/site-packages/setuptools/sandbox.py", line 29, in run_setup
    lambda: execfile(
  File "/usr/lib/python2.6/site-packages/setuptools/sandbox.py", line 70, in run
    return func()
  File "/usr/lib/python2.6/site-packages/setuptools/sandbox.py", line 31, in <lambda>
    {'__file__':setup_script, '__name__':'__main__'}
  File "setup.py", line 46, in <module>
    'fs==0.4.0',
ImportError: cannot import name URL_GH_HPCUGENT
```