### PR TITLE
fix setup.py, vsc-base (also) provides 'vsc' namespace

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,10 @@ VSC_INSTALL_REQ_VERSION = '0.9.0'
 
 PACKAGE = {
     'name': 'vsc-base',
-    'version': '2.4.9',
+    'version': '2.4.9.1',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
-    'packages': ['vsc.utils'],
+    'packages': ['vsc', 'vsc.utils'],
     'scripts': ['bin/logdaemon.py', 'bin/startlogdaemon.sh', 'bin/bdist_rpm.sh', 'bin/optcomplete.bash'],
     'install_requires': ['vsc-install >= %s' % VSC_INSTALL_REQ_VERSION], # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger
     'setup_requires': ['vsc-install >= %s' % VSC_INSTALL_REQ_VERSION],

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ VSC_INSTALL_REQ_VERSION = '0.9.0'
 
 PACKAGE = {
     'name': 'vsc-base',
-    'version': '2.4.9.1',
+    'version': '2.4.10',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     'packages': ['vsc', 'vsc.utils'],


### PR DESCRIPTION
this is required to have `vsc/__init__.py` installed with vsc-base...

not sure if anything else is required to avoid shipping `vsc/__init__.py` in `vsc-base` RPMs