### PR TITLE
only include root logger name in non-debug mode

### DIFF
--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -357,7 +357,9 @@ def getLogger(name=None, fname=False, clsname=False, fancyrecord=None):
     FANCYLOG_FANCYRECORD to False, or will also be disabled if a Name is set (and fancyrecord and
     module constant FANCYLOG_FANCYRECORD are also not set).
     """
-    nameparts = [getRootLoggerName()]
+    nameparts = []
+    if __debug__:
+        nameparts.append(getRootLoggerName())
 
     if fancyrecord is None:
         # Altough we could set it as default value in the function definition

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ from vsc.install.shared_setup import ag, kh, jt, sdw
 VSC_INSTALL_REQ_VERSION = '0.9.19'
 
 PACKAGE = {
-    'version': '2.4.18',
+    'version': '2.4.19',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger


### PR DESCRIPTION
`getRootLoggerName()` always returns "not available in optimized mode" when it is run under `python -O` (i.e., when `__debug__` is `False`), so it makes no sense to include it to construct the "full logger name"