### PR TITLE
Add support for colorization of log messages sent to the screen.

### DIFF
--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -543,7 +543,7 @@ def logToUDP(hostname, port=5005, enable=True, datagramhandler=None, name=None):
 
 
 def _logToSomething(handlerclass, handleropts, loggeroption,
-                    enable=True, name=None, handler=None, formatterclass=logging.Formatter):
+                    enable=True, name=None, handler=None, formatterclass=None):
     """
     internal function to enable (or disable) logging to handler named handlername
     handleropts is options dictionary passed to create the handler instance
@@ -553,6 +553,9 @@ def _logToSomething(handlerclass, handleropts, loggeroption,
     if you want to disable logging to the handler, pass the earlier obtained handler
     """
     logger = getLogger(name, fname=False, clsname=False)
+
+    if formatterclass is None:
+        formatterclass = logging.Formatter
 
     if not hasattr(logger, loggeroption):
         # not set.

--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -682,8 +682,7 @@ def _screenLogFormatterFactory(colorize=Colorize.NEVER, stream=sys.stdout):
         elif colorize == Colorize.ALWAYS:
             formatter = coloredlogs.ColoredFormatter
         else:
-            assert colorize == Colorize.NEVER, \
-                "Argument `colorize` must be one of 'auto', 'always', or 'never'."
+            raise ValueError("Argument `colorize` must be one of 'auto', 'always', or 'never'.")
     return formatter
 
 

--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -75,6 +75,7 @@ Logging to a udp server:
 @author: Kenneth Hoste (Ghent University)
 """
 
+from collections import namedtuple
 import inspect
 import logging
 import logging.handlers
@@ -175,11 +176,7 @@ BACKUPCOUNT = 10  # number of rotating log files to save
 DEFAULT_UDP_PORT = 5005
 
 # poor man's enum
-class Colorize:
-    """Allowed values for the `logToScreen`'s `colorize` parameter."""
-    AUTO = 'auto'
-    ALWAYS = 'always'
-    NEVER = 'never'
+Colorize = namedtuple('Colorize', 'AUTO ALWAYS NEVER')('auto', 'always', 'never')
 
 # register new loglevelname
 logging.addLevelName(logging.CRITICAL * 2 + 1, 'APOCALYPTIC')

--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -442,7 +442,7 @@ def getRootLoggerName():
         return "not available in optimized mode"
 
 
-def logToScreen(enable=True, handler=None, name=None, stdout=False, color=None):
+def logToScreen(enable=True, handler=None, name=None, stdout=False, color=False):
     """
     enable (or disable) logging to screen
     returns the screenhandler (this can be used to later disable logging to screen)
@@ -458,27 +458,22 @@ def logToScreen(enable=True, handler=None, name=None, stdout=False, color=None):
     The `color` parameter enables or disables log colorization using
     ANSI terminal escape sequences, according to the following values:
 
-    * when `color` is ``auto`` or ``None`` (default), then try to
+    * when `color` is ``auto``, then try to
       auto-detect whether the output stream is connected to a terminal;
     * when `color` is ``True`` or the string ``'yes'``, then turn on
       log colorization unconditionally,
-    * any other value turns off log colorization unconditionally.
+    * any other value turns off log colorization unconditionally (default).
     """
     handleropts = {'stdout': stdout}
 
-    use_color_formatter = False  # default
+    formatter = logging.Formatter  # default
     if HAVE_COLOREDLOGS_MODULE:
-        if color is None or color == 'auto':
+        if color == 'auto':
             # auto-detect
             if humanfriendly.terminal.terminal_supports_colors(sys.stdout if stdout else sys.stderr):
-                use_color_formatter = True
+                formatter = coloredlogs.ColoredFormatter
         elif color is True or color == 'yes':
-            use_color_formatter = True
-
-    if use_color_formatter:
-        formatter = coloredlogs.ColoredFormatter
-    else:
-        formatter = logging.Formatter
+            formatter = coloredlogs.ColoredFormatter
 
     return _logToSomething(FancyStreamHandler,
                            handleropts,
@@ -486,7 +481,7 @@ def logToScreen(enable=True, handler=None, name=None, stdout=False, color=None):
                            name=name,
                            enable=enable,
                            handler=handler,
-                           formatterclass=formatter
+                           formatterclass=formatter,
                            )
 
 

--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -463,7 +463,7 @@ def logToScreen(enable=True, handler=None, name=None, stdout=False, colorize='ne
     (which see).
     """
     handleropts = {'stdout': stdout}
-    formatter = _screenLogFormatterFactory(colorize=color, stream=(sys.stdout if stdout else sys.stderr))
+    formatter = _screenLogFormatterFactory(colorize=colorizec, stream=(sys.stdout if stdout else sys.stderr))
 
     return _logToSomething(FancyStreamHandler,
                            handleropts,

--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -85,12 +85,14 @@ import traceback
 import weakref
 from distutils.version import LooseVersion
 
-try:
-    import coloredlogs
-    import humanfriendly
-    HAVE_COLOREDLOGS_MODULE = True
-except ImportError:
-    HAVE_COLOREDLOGS_MODULE = False
+HAVE_COLOREDLOGS_MODULE = False
+if os.environ.get('FANCYLOGGER_NO_COLOREDLOGS', '0').lower() not in ('1', 'yes', 'true', 'y'):
+    try:
+        import coloredlogs
+        import humanfriendly
+        HAVE_COLOREDLOGS_MODULE = True
+    except ImportError:
+        pass
 
 # constants
 TEST_LOGGING_FORMAT = '%(levelname)-10s %(name)-15s %(threadName)-10s  %(message)s'

--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -463,7 +463,7 @@ def logToScreen(enable=True, handler=None, name=None, stdout=False, colorize='ne
     (which see).
     """
     handleropts = {'stdout': stdout}
-    formatter = _screenLogFormatterFactory(colorize=colorizec, stream=(sys.stdout if stdout else sys.stderr))
+    formatter = _screenLogFormatterFactory(colorize=colorize, stream=(sys.stdout if stdout else sys.stderr))
 
     return _logToSomething(FancyStreamHandler,
                            handleropts,

--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -86,7 +86,7 @@ import weakref
 from distutils.version import LooseVersion
 
 
-def _disabled_by_environ(varname, default=False):
+def _disabled_by_environ(varname, default=True):
     """
     Compute a boolean based on the truth value of environment variable `varname`.
     If no variable by that name is present in `os.environ`, then return `default`.
@@ -137,11 +137,11 @@ def _disabled_by_environ(varname, default=False):
       42
 
     By default, calling `_disabled_by_environ` on an undefined
-    variable returns Python ``False``::
+    variable returns Python ``True``::
 
       >>> if 'NO_FOOBAR' in os.environ: del os.environ['NO_FOOBAR']
       >>> _disabled_by_environ('NO_FOOBAR')
-      False
+      True
     """
     if varname not in os.environ:
         return default

--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -681,6 +681,8 @@ def _screenLogFormatterFactory(colorize=Colorize.NEVER, stream=sys.stdout):
                 formatter = coloredlogs.ColoredFormatter
         elif colorize == Colorize.ALWAYS:
             formatter = coloredlogs.ColoredFormatter
+        elif colorize == Colorize.NEVER:
+            pass
         else:
             raise ValueError("Argument `colorize` must be one of 'auto', 'always', or 'never'.")
     return formatter

--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -86,7 +86,7 @@ import weakref
 from distutils.version import LooseVersion
 
 
-def _disabled_by_environ(varname, default=True):
+def _env_to_boolean(varname, default=False):
     """
     Compute a boolean based on the truth value of environment variable `varname`.
     If no variable by that name is present in `os.environ`, then return `default`.
@@ -96,52 +96,52 @@ def _disabled_by_environ(varname, default=True):
     mapped to the truth value ``True``::
 
       >>> os.environ['NO_FOOBAR'] = '1'
-      >>> _disabled_by_environ('NO_FOOBAR')
+      >>> _env_to_boolean('NO_FOOBAR')
       True
       >>> os.environ['NO_FOOBAR'] = 'Y'
-      >>> _disabled_by_environ('NO_FOOBAR')
+      >>> _env_to_boolean('NO_FOOBAR')
       True
       >>> os.environ['NO_FOOBAR'] = 'Yes'
-      >>> _disabled_by_environ('NO_FOOBAR')
+      >>> _env_to_boolean('NO_FOOBAR')
       True
       >>> os.environ['NO_FOOBAR'] = 'yes'
-      >>> _disabled_by_environ('NO_FOOBAR')
+      >>> _env_to_boolean('NO_FOOBAR')
       True
       >>> os.environ['NO_FOOBAR'] = 'True'
-      >>> _disabled_by_environ('NO_FOOBAR')
+      >>> _env_to_boolean('NO_FOOBAR')
       True
       >>> os.environ['NO_FOOBAR'] = 'TRUE'
-      >>> _disabled_by_environ('NO_FOOBAR')
+      >>> _env_to_boolean('NO_FOOBAR')
       True
       >>> os.environ['NO_FOOBAR'] = 'true'
-      >>> _disabled_by_environ('NO_FOOBAR')
+      >>> _env_to_boolean('NO_FOOBAR')
       True
 
     Any other value is mapped to Python ``False``::
 
       >>> os.environ['NO_FOOBAR'] = '0'
-      >>> _disabled_by_environ('NO_FOOBAR')
+      >>> _env_to_boolean('NO_FOOBAR')
       False
       >>> os.environ['NO_FOOBAR'] = 'no'
-      >>> _disabled_by_environ('NO_FOOBAR')
+      >>> _env_to_boolean('NO_FOOBAR')
       False
       >>> os.environ['NO_FOOBAR'] = 'if you please'
-      >>> _disabled_by_environ('NO_FOOBAR')
+      >>> _env_to_boolean('NO_FOOBAR')
       False
 
     If no variable named `varname` is present in `os.environ`, then
     return `default`::
 
       >>> del os.environ['NO_FOOBAR']
-      >>> _disabled_by_environ('NO_FOOBAR', 42)
+      >>> _env_to_boolean('NO_FOOBAR', 42)
       42
 
-    By default, calling `_disabled_by_environ` on an undefined
-    variable returns Python ``True``::
+    By default, calling `_env_to_boolean` on an undefined
+    variable returns Python ``False``::
 
       >>> if 'NO_FOOBAR' in os.environ: del os.environ['NO_FOOBAR']
-      >>> _disabled_by_environ('NO_FOOBAR')
-      True
+      >>> _env_to_boolean('NO_FOOBAR')
+      False
     """
     if varname not in os.environ:
         return default
@@ -150,7 +150,7 @@ def _disabled_by_environ(varname, default=True):
 
 
 HAVE_COLOREDLOGS_MODULE = False
-if not _disabled_by_environ('FANCYLOGGER_NO_COLOREDLOGS'):
+if not _env_to_boolean('FANCYLOGGER_NO_COLOREDLOGS'):
     try:
         import coloredlogs
         import humanfriendly
@@ -184,7 +184,7 @@ logging._levelNames['QUIET'] = logging.WARNING
 
 # mpi rank support
 _MPIRANK = MPIRANK_NO_MPI
-if not _disabled_by_environ('FANCYLOGGER_IGNORE_MPI4PY'):
+if not _env_to_boolean('FANCYLOGGER_IGNORE_MPI4PY'):
     try:
         from mpi4py import MPI
         if MPI.Is_initialized():
@@ -456,7 +456,7 @@ def getLogger(name=None, fname=False, clsname=False, fancyrecord=None):
 
     l = logging.getLogger(fullname)
     l.fancyrecord = fancyrecord
-    if not _disabled_by_environ('FANCYLOGGER_GETLOGGER_DEBUG'):
+    if _env_to_boolean('FANCYLOGGER_GETLOGGER_DEBUG'):
         print 'FANCYLOGGER_GETLOGGER_DEBUG',
         print 'name', name, 'fname', fname, 'fullname', fullname,
         print "getRootLoggerName: ", getRootLoggerName()
@@ -716,7 +716,7 @@ def setLogLevel(level):
         level = getLevelInt(level)
     logger = getLogger(fname=False, clsname=False)
     logger.setLevel(level)
-    if not _disabled_by_environ('FANCYLOGGER_LOGLEVEL_DEBUG'):
+    if _env_to_boolean('FANCYLOGGER_LOGLEVEL_DEBUG'):
         print "FANCYLOGGER_LOGLEVEL_DEBUG", level, logging.getLevelName(level)
         print "\n".join(logger.get_parent_info("FANCYLOGGER_LOGLEVEL_DEBUG"))
         sys.stdout.flush()

--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -458,16 +458,12 @@ def logToScreen(enable=True, handler=None, name=None, stdout=False, color='never
     by setting the 'stdout' parameter to True
 
     The `color` parameter enables or disables log colorization using
-    ANSI terminal escape sequences, according to the following values:
-
-    * when `color` is ``auto``, then try to
-      auto-detect whether the output stream is connected to a terminal;
-    * when `color` is the string ``'always'``, then turn on
-      log colorization unconditionally,
-    * any other value turns off log colorization unconditionally (default).
+    ANSI terminal escape sequences, according to the values allowed
+    in the `colorize` parameter to function `_screenLogFormatterFactory`
+    (which see).
     """
     handleropts = {'stdout': stdout}
-    formatter = _getScreenLogFormatter((sys.stdout if stdout else sys.stderr), color)
+    formatter = _screenLogFormatterFactory(color, sys.stdout if stdout else sys.stderr)
 
     return _logToSomething(FancyStreamHandler,
                            handleropts,
@@ -540,7 +536,8 @@ def _logToSomething(handlerclass, handleropts, loggeroption,
                     enable=True, name=None, handler=None, formatterclass=None):
     """
     internal function to enable (or disable) logging to handler named handlername
-    handleropts is options dictionary passed to create the handler instance
+    handleropts is options dictionary passed to create the handler instance;
+    `formatterclass` is the class to use to instanciate a log formatter object.
 
     returns the handler (this can be used to later disable logging to file)
 
@@ -590,16 +587,18 @@ def _logToSomething(handlerclass, handleropts, loggeroption,
     return handler
 
 
-def _getScreenLogFormatter(stream, colorize='never'):
+def _screenLogFormatterFactory(colorize='never', stream=sys.stdout):
     """
-    Return a log formatter, with optional colorization features.
+    Return a log formatter class, with optional colorization features.
 
     Second argument `colorize` controls whether the formatter
     can use ANSI terminal escape sequences:
 
-    * ``'never'`` (default) forces use of the plain `logging.Formatter` class;
+    * ``'never'`` (default) forces use the plain `logging.Formatter` class;
     * ``'always'`` forces use of the colorizing formatter;
     * ``'auto'`` selects the colorizing formatter depending on whether `stream` is connected to a terminal.
+
+    Second argument `stream` is the stream to check in case `colorize` is ``'auto'``.
     """
     formatter = logging.Formatter  # default
     if HAVE_COLOREDLOGS_MODULE:

--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -444,7 +444,7 @@ def getRootLoggerName():
         return "not available in optimized mode"
 
 
-def logToScreen(enable=True, handler=None, name=None, stdout=False, color='never'):
+def logToScreen(enable=True, handler=None, name=None, stdout=False, colorize='never'):
     """
     enable (or disable) logging to screen
     returns the screenhandler (this can be used to later disable logging to screen)
@@ -457,13 +457,13 @@ def logToScreen(enable=True, handler=None, name=None, stdout=False, color='never
     by default, logToScreen will log to stderr; logging to stdout instead can be done
     by setting the 'stdout' parameter to True
 
-    The `color` parameter enables or disables log colorization using
+    The `colorize` parameter enables or disables log colorization using
     ANSI terminal escape sequences, according to the values allowed
     in the `colorize` parameter to function `_screenLogFormatterFactory`
     (which see).
     """
     handleropts = {'stdout': stdout}
-    formatter = _screenLogFormatterFactory(color, sys.stdout if stdout else sys.stderr)
+    formatter = _screenLogFormatterFactory(colorize=color, stream=(sys.stdout if stdout else sys.stderr))
 
     return _logToSomething(FancyStreamHandler,
                            handleropts,
@@ -537,7 +537,7 @@ def _logToSomething(handlerclass, handleropts, loggeroption,
     """
     internal function to enable (or disable) logging to handler named handlername
     handleropts is options dictionary passed to create the handler instance;
-    `formatterclass` is the class to use to instanciate a log formatter object.
+    `formatterclass` is the class to use to instantiate a log formatter object.
 
     returns the handler (this can be used to later disable logging to file)
 
@@ -608,6 +608,8 @@ def _screenLogFormatterFactory(colorize='never', stream=sys.stdout):
                 formatter = coloredlogs.ColoredFormatter
         elif colorize == 'always':
             formatter = coloredlogs.ColoredFormatter
+        else:
+            assert colorize == 'never', "Argument `colorize` must be one of 'auto', 'always', or 'never'."
     return formatter
 
 

--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -174,6 +174,13 @@ BACKUPCOUNT = 10  # number of rotating log files to save
 
 DEFAULT_UDP_PORT = 5005
 
+# poor man's enum
+class Colorize:
+    """Allowed values for the `logToScreen`'s `colorize` parameter."""
+    AUTO = 'auto'
+    ALWAYS = 'always'
+    NEVER = 'never'
+
 # register new loglevelname
 logging.addLevelName(logging.CRITICAL * 2 + 1, 'APOCALYPTIC')
 # register QUIET, EXCEPTION and FATAL alias
@@ -508,7 +515,7 @@ def getRootLoggerName():
         return "not available in optimized mode"
 
 
-def logToScreen(enable=True, handler=None, name=None, stdout=False, colorize='never'):
+def logToScreen(enable=True, handler=None, name=None, stdout=False, colorize=Colorize.NEVER):
     """
     enable (or disable) logging to screen
     returns the screenhandler (this can be used to later disable logging to screen)
@@ -651,29 +658,32 @@ def _logToSomething(handlerclass, handleropts, loggeroption,
     return handler
 
 
-def _screenLogFormatterFactory(colorize='never', stream=sys.stdout):
+def _screenLogFormatterFactory(colorize=Colorize.NEVER, stream=sys.stdout):
     """
     Return a log formatter class, with optional colorization features.
 
     Second argument `colorize` controls whether the formatter
     can use ANSI terminal escape sequences:
 
-    * ``'never'`` (default) forces use the plain `logging.Formatter` class;
-    * ``'always'`` forces use of the colorizing formatter;
-    * ``'auto'`` selects the colorizing formatter depending on whether `stream` is connected to a terminal.
+    * ``Colorize.NEVER`` (default) forces use the plain `logging.Formatter` class;
+    * ``Colorize.ALWAYS`` forces use of the colorizing formatter;
+    * ``Colorize.AUTO`` selects the colorizing formatter depending on
+      whether `stream` is connected to a terminal.
 
-    Second argument `stream` is the stream to check in case `colorize` is ``'auto'``.
+    Second argument `stream` is the stream to check in case `colorize`
+    is ``Colorize.AUTO``.
     """
     formatter = logging.Formatter  # default
     if HAVE_COLOREDLOGS_MODULE:
-        if colorize == 'auto':
+        if colorize == Colorize.AUTO:
             # auto-detect
             if humanfriendly.terminal.terminal_supports_colors(stream):
                 formatter = coloredlogs.ColoredFormatter
-        elif colorize == 'always':
+        elif colorize == Colorize.ALWAYS:
             formatter = coloredlogs.ColoredFormatter
         else:
-            assert colorize == 'never', "Argument `colorize` must be one of 'auto', 'always', or 'never'."
+            assert colorize == Colorize.NEVER, \
+                "Argument `colorize` must be one of 'auto', 'always', or 'never'."
     return formatter
 
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,11 @@ from vsc.install.shared_setup import ag, kh, jt, sdw
 
 VSC_INSTALL_REQ_VERSION = '0.10.1'
 
+_coloredlogs_pkgs = [
+    'coloredlogs',     # automatic log colorizer
+    'humanfriendly',   # detect if terminal has colors
+]
+
 PACKAGE = {
     'version': '2.5.3',
     'author': [sdw, jt, ag, kh],
@@ -46,12 +51,10 @@ PACKAGE = {
     # setuptools must become a requirement for shared namespaces if vsc-install is removed as requirement
     'install_requires': ['vsc-install >= %s' % VSC_INSTALL_REQ_VERSION],
     'extras_require': {
-        'coloredlogs': [
-            'coloredlogs',     # automatic log colorizer
-            'humanfriendly',   # detect if terminal has colors
-        ],
+        'coloredlogs': _coloredlogs_pkgs,
     },
     'setup_requires': ['vsc-install >= %s' % VSC_INSTALL_REQ_VERSION],
+    'tests_require': _coloredlogs_pkgs,
 }
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ from vsc.install.shared_setup import ag, kh, jt, sdw
 VSC_INSTALL_REQ_VERSION = '0.10.1'
 
 PACKAGE = {
-    'version': '2.5.2',
+    'version': '2.5.3',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ PACKAGE = {
         'coloredlogs': _coloredlogs_pkgs,
     },
     'setup_requires': ['vsc-install >= %s' % VSC_INSTALL_REQ_VERSION],
-    'tests_require': _coloredlogs_pkgs,
+    'tests_require': ['prospector'] + _coloredlogs_pkgs,
 }
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,11 @@ PACKAGE = {
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger
     # setuptools must become a requirement for shared namespaces if vsc-install is removed as requirement
-    'install_requires': ['vsc-install >= %s' % VSC_INSTALL_REQ_VERSION],
+    'install_requires': [
+        'vsc-install >= %s' % VSC_INSTALL_REQ_VERSION,
+        'coloredlogs',     # automatic log colorizer
+        'humanfriendly',   # detect if terminal has colors
+    ],
     'setup_requires': ['vsc-install >= %s' % VSC_INSTALL_REQ_VERSION],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,13 @@ PACKAGE = {
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger
     # setuptools must become a requirement for shared namespaces if vsc-install is removed as requirement
-    'install_requires': [
-        'vsc-install >= %s' % VSC_INSTALL_REQ_VERSION,
-        'coloredlogs',     # automatic log colorizer
-        'humanfriendly',   # detect if terminal has colors
-    ],
+    'install_requires': ['vsc-install >= %s' % VSC_INSTALL_REQ_VERSION],
+    'extras_require': {
+        'coloredlogs': [
+            'coloredlogs',     # automatic log colorizer
+            'humanfriendly',   # detect if terminal has colors
+        ],
+    },
     'setup_requires': ['vsc-install >= %s' % VSC_INSTALL_REQ_VERSION],
 }
 

--- a/test/fancylogger.py
+++ b/test/fancylogger.py
@@ -75,13 +75,11 @@ def _get_tty_stream():
                 stream = open(tty, 'w')
                 if os.isatty(stream.fileno()):
                     return stream
-                else:
-                    return None
             except IOError:
-                return None
-        else:
-            # give up
-            return None
+                # cannot open $TTY for writing, continue
+                pass
+        # give up
+        return None
 
 
 def classless_function():


### PR DESCRIPTION
The support depends on the external modules `coloredlogs` and
`humanfriendly`; if they are not available, logs will not be colorized
no matter what.

An additional option to `fancylogger.logToScreen()` allows turning log
colorization depending on terminal capabilities, or on/off unconditionally.

**Note that this makes EasyBuild logs colored by default!**