### PR TITLE
Provide the correct number of arguments

### DIFF
--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -318,8 +318,8 @@ class Run(object):
         """Initialise the self._process"""
         try:
             self._process = self._process_module.Popen(self._shellcmd, **self._popen_named_args)
-        except OSError:
-            self.log.raiseException("_init_process: init Popen shellcmd %s failed: %s" % (self._shellcmd))
+        except OSError, err:
+            self.log.raiseException("_init_process: init Popen shellcmd %s failed: %s" % (self._shellcmd, err))
 
     def _init_input(self):
         """Handle input, if any in a simple way"""

--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -319,7 +319,7 @@ class Run(object):
         try:
             self._process = self._process_module.Popen(self._shellcmd, **self._popen_named_args)
         except OSError as err:
-            self.log.exception("_init_process: init Popen shellcmd %s failed: %s" % (self._shellcmd, err))
+            self.log.exception("_init_process: init Popen shellcmd %s failed: %s", self._shellcmd, err)
             raise
 
     def _init_input(self):

--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -319,7 +319,8 @@ class Run(object):
         try:
             self._process = self._process_module.Popen(self._shellcmd, **self._popen_named_args)
         except OSError as err:
-            self.log.raiseException("_init_process: init Popen shellcmd %s failed: %s" % (self._shellcmd, err))
+            self.log.exception("_init_process: init Popen shellcmd %s failed: %s" % (self._shellcmd, err))
+            raise
 
     def _init_input(self):
         """Handle input, if any in a simple way"""

--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -318,7 +318,7 @@ class Run(object):
         """Initialise the self._process"""
         try:
             self._process = self._process_module.Popen(self._shellcmd, **self._popen_named_args)
-        except OSError, err:
+        except OSError as err:
             self.log.raiseException("_init_process: init Popen shellcmd %s failed: %s" % (self._shellcmd, err))
 
     def _init_input(self):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: latin-1 -*-
 #
-# Copyright 2009-2014 Ghent University
+# Copyright 2009-2016 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '2.5.4',
+    'version': '2.5.5',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger


### PR DESCRIPTION
Noticed when running tests for vsc-jobs.

~~~~
ERROR: test_run_subshell (test.submitfilter_bin.TestSubmitfilter)
Read data from testjobs_submitfilter and feed it through submitfilter script
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ageorges/hpcugent/vsc-jobs/test/submitfilter_bin.py", line 237, in test_run_subshell
    ec, output = run_simple(cmd, input=open(script).read())
  File "/home/ageorges/hpcugent/vsc/lib/python2.7/site-packages/vsc_base-2.5.4-py2.7.egg/vsc/utils/run.py", line 108, in run
    return r._run()
  File "/home/ageorges/hpcugent/vsc/lib/python2.7/site-packages/vsc_base-2.5.4-py2.7.egg/vsc/utils/run.py", line 212, in _run
    self._run_pre()
  File "/home/ageorges/hpcugent/vsc/lib/python2.7/site-packages/vsc_base-2.5.4-py2.7.egg/vsc/utils/run.py", line 230, in _run_pre
    self._init_process()
  File "/home/ageorges/hpcugent/vsc/lib/python2.7/site-packages/vsc_base-2.5.4-py2.7.egg/vsc/utils/run.py", line 322, in _init_process
    self.log.raiseException("_init_process: init Popen shellcmd %s failed: %s" % (self._shellcmd))
TypeError: not enough arguments for format string
~~~~