### PR TITLE
add Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+install:
+  - easy_install vsc-install
+script:
+  # 'hpcugent' is a mandatory remote for setup.py to work (because of vsc-install)
+  - git remote add hpcugent https://github.com/hpcugent/vsc-base.git
+  - python setup.py test


### PR DESCRIPTION
Same motivation as in https://github.com/hpcugent/vsc-install/pull/84: we can stick to testing on Jenkins, but having a Travis config file in our repository is helpful for contributors (cfr. #258)