### PR TITLE
specify that long description is in Markdown format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '2.7.0',
+    'version': '2.7.1',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger
@@ -55,6 +55,7 @@ PACKAGE = {
     },
     'setup_requires': ['vsc-install >= %s' % VSC_INSTALL_REQ_VERSION],
     'tests_require': ['prospector'] + _coloredlogs_pkgs,
+    'long_description_content_type': 'text/markdown',
 }
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix for problem with uploading to PyPI:

```
$ python setup.py sdist upload
...
INFO: running upload
Upload failed (400): The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.
error: Upload failed (400): The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.
```

It's a bit strange this hasn't popped up before; in the long run, we should probably fix this in `vsc-install` instead, but let's see if this fixes the issue first...