### PR TITLE
derive FrozenDict from collections.Mapping rather than DictMixin

### DIFF
--- a/lib/vsc/utils/frozendict.py
+++ b/lib/vsc/utils/frozendict.py
@@ -21,14 +21,12 @@ frozendict is an immutable wrapper around dictionaries that implements the compl
 It can be used as a drop-in replacement for dictionaries where immutability is desired.
 """
 import operator
-from UserDict import DictMixin
+from collections import Mapping
 
 
 # minor adjustments:
 # * renamed to FrozenDict
-# * deriving from DictMixin instead of collections.Mapping to make it Python 2.4 compatible
-#   see also http://docs.python.org/2/library/userdict.html#UserDict.DictMixin
-class FrozenDict(object, DictMixin):
+class FrozenDict(Mapping):
 
     def __init__(self, *args, **kwargs):
         self.__dict = dict(*args, **kwargs)

--- a/lib/vsc/utils/patterns.py
+++ b/lib/vsc/utils/patterns.py
@@ -36,10 +36,11 @@ script.
 
 @author: Andy Georges (Ghent University)
 """
+from abc import ABCMeta
 
 
-class Singleton(type):
-    """Serves as  metaclass for classes that should implement the Singleton pattern.
+class Singleton(ABCMeta):
+    """Serves as metaclass for classes that should implement the Singleton pattern.
 
     See http://stackoverflow.com/questions/6760685/creating-a-singleton-in-python
     """

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '2.7.2',
+    'version': '2.7.3',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger

--- a/test/missing.py
+++ b/test/missing.py
@@ -35,6 +35,7 @@ from random import randint, seed
 from vsc.utils.missing import get_class_for, get_subclasses, get_subclasses_dict
 from vsc.utils.missing import nub, topological_sort, FrozenDictKnownKeys, TryOrFail
 from vsc.utils.missing import namedtuple_with_defaults
+from vsc.utils.patterns import Singleton
 from vsc.install.testing import TestCase
 
 
@@ -225,6 +226,25 @@ class TestMissing(TestCase):
         # test ignoring of unknown keys
         tfdkk = TestFrozenDictKnownKeys({'foo': 'bar', 'foo2': 'bar2', 'foo3': 'bar3'}, ignore_unknown_keys=True)
         self.assertEqual(sorted(tfdkk.keys()), ['foo', 'foo2'])
+
+    def test_frozendictknownkeys_singleton(self):
+        """
+        Test use of a FrozenDictKnownKeys class that is also a singleton.
+        This is a use case from EasyBuild (see ConfigurationVariables class in easybuild.tools.config).
+        """
+
+        class TestFrozenDictKnownKeysSingleton(FrozenDictKnownKeys):
+            """Inner test class derived from FrozenDictKnownKeys."""
+            __metaclass__ = Singleton
+            KNOWN_KEYS = ['foo', 'foo2']
+
+        td = TestFrozenDictKnownKeysSingleton({'foo': 'bar'})
+        self.assertEqual(td, {'foo': 'bar'})
+
+        # singleton aspect ensures that we get same instance again later (even if unknown keys are provided)
+        td_bis = TestFrozenDictKnownKeysSingleton({'foo3': 'bar3'})
+        self.assertEqual(td_bis, {'foo': 'bar'})
+        self.assertTrue(td is td_bis)
 
     def test_fixed_topological_sort(self):
         """

--- a/test/missing.py
+++ b/test/missing.py
@@ -218,7 +218,7 @@ class TestMissing(TestCase):
 
         # no (direct) way of adjusting dictionary
         self.assertErrorRegex(AttributeError, ".*has no attribute.*", lambda x: tfdkk.__setitem__(x), ('foo2', 'bar2'))
-        self.assertErrorRegex(TypeError, ".*not support item assignment.*", lambda x: tfdkk.update(x), {'foo2': 'bar2'})
+        self.assertErrorRegex(AttributeError, ".*has no attribute.*", lambda x: tfdkk.update(x), {'foo2': 'bar2'})
         # unknown keys are not allowed
         self.assertErrorRegex(KeyError, 'Encountered unknown keys', TestFrozenDictKnownKeys, {'foo3': 'bar3'})
 


### PR DESCRIPTION
deriving from `DictMixin` was done to support Python 2.4, which is no longer relevant

This change significantly simplifies porting `FrozenDict` to Python 3.x (cfr. #258), which is relevant for EasyBuild (and only there, `FrozenDict` and `FrozenDictKnownKeys` are only using in EasyBuild framework as far as I can tell).

The change from `DictMixin` to `Mapping` seems trivial, but I noticed that EasyBuild started failing after doing it naively. I reproduced the problem I was hitting in the new test that is also added here.

Without deriving `Singleton` from `ABCMeta`, the test fails with:

```
======================================================================
ERROR: test_frozendictknownkeys_singleton (test.missing.TestMissing)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Volumes/work/vsc-base/test/missing.py", line 236, in test_frozendictknownkeys_singleton
    class TestFrozenDictKnownKeysSingleton(FrozenDictKnownKeys):
TypeError: Error when calling the metaclass bases
    metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases
```

It took me a while to figure it out, but there problem is basically that:

* `FrozenDictKnownKeys` now has a non-default metaclass because it derives from `collections.Mapping`:
    ```
    $python -c "from vsc.utils.missing import FrozenDictKnownKeys; print FrozenDictKnownKeys.__metaclass__"
    <class 'abc.ABCMeta'>
    ```

    (before the metaclass was undefined, which means it defaults to `type`)

* the Method Resolution Order (MRO) for `Singleton` was:
   ```
    python -c "from vsc.utils.patterns import Singleton; print Singleton.__mro__"
    (<class 'vsc.utils.patterns.Singleton'>, <type 'type'>, <type 'object'>)
   ```
   This doesn't include `ABCMeta`, which is the problem

* after deriving `Singleton` from `ABCMeta`, the MRO changes to:
   ```
    $ python -c "from vsc.utils.patterns import Singleton; print Singleton.__mro__"
    (<class 'vsc.utils.patterns.Singleton'>, <class 'abc.ABCMeta'>, <type 'type'>, <type 'object'>)
   ```

The change in `Singleton` shouldn't break anything, since it doesn't change the semantics at all (I checked this by running the `vsc-config` and `easybuild-framework` tests on top of this change, both use `Singleton`).

This link was useful in figuring this out: http://code.activestate.com/recipes/204197-solving-the-metaclass-conflict/