### PR TITLE
add CmdList wrapper for list type as helper for constructing commands

### DIFF
--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -86,6 +86,48 @@ BASH = '/bin/bash'
 SHELL = BASH
 
 
+class CmdList(list):
+    """Wrapper for 'list' type to be used for constructing a list of options & arguments for a command."""
+
+    def __init__(self, cmd=None):
+        """
+        Create CmdList instance to construct command
+
+        :param cmd: actual command to run (first item in list)
+        """
+        super(CmdList, self).__init__()
+        if cmd is not None:
+            if isinstance(cmd, list):
+                super(CmdList, self).extend(cmd)
+            else:
+                super(CmdList, self).append(cmd)
+
+    def add_opts_args(self, items, tmpl_vals=None, allow_spaces=True):
+        """
+        Add options/arguments to command
+
+        :param item: option/argument to add to command
+        :param tmpl_vals: template values for item
+        """
+        if isinstance(items, basestring):
+            items = [items]
+
+        for item in items:
+            if tmpl_vals:
+                item = item % tmpl_vals
+
+            if not allow_spaces and ' ' in item:
+                raise ValueError("Found one or more spaces in item '%s' being added to command %s" % (item, self))
+
+            super(CmdList, self).append(item)
+
+    def append(self, *args, **kwargs):
+        raise NotImplementedError("Use add_opts_args rather than append")
+
+    def extend(self, *args, **kwargs):
+        raise NotImplementedError("Use add_opts_args rather than extend")
+
+
 class DummyFunction(object):
     def __getattr__(self, name):
         def dummy(*args, **kwargs):  # pylint: disable=unused-argument

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '2.7.5',
+    'version': '2.8.0',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger


### PR DESCRIPTION
`mympirun` is currently broken because of the naive switch from `run_simple` to `run` in https://github.com/hpcugent/vsc-mympirun/pull/144 .

When using `run` with a list to specify the command, *none* of the items in the list should be a combination of separate arguments, otherwise they will be treated as an argument as a whole, leading to errors like `unrecognized argument machinefile  /user/home/gent/vsc400/vsc40023/.mympirun_bfxlm3/4473084.master15.delcatty.gent.vsc_20180606_151207/nodes` (where `machinefile` and the `.../nodes` path are supposed to be passed as separate arguments rather than as a string combining both).

In addition, all elements in the command list *must* be strings. If not, it leads to errors like:

```
Traceback (most recent call last):
  File "/user/scratchphanpy/gent/gvo000/gvo00002/vsc40023/easybuild_REGTEST/CO7/sandybridge/software/vsc-mympirun/4.1.4dev/lib/python2.7/site-packages/vsc_mympirun-4.1.4-py2.7.egg/EGG-INFO/scripts/mympirun", line 124, in main
    instance.main()
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/sandybridge/software/vsc-mympirun/4.1.4dev/lib/python2.7/site-packages/vsc_mympirun-4.1.4-py2.7.egg/vsc/mympirun/mpi/mpi.py", line 450, in main
    exitcode, _ = run_mpirun_cmd(self.mpirun_cmd, **run_kwargs)
  File "build/bdist.linux-x86_64/egg/vsc/utils/run.py", line 151, in run
    return r._run()
  File "build/bdist.linux-x86_64/egg/vsc/utils/run.py", line 255, in _run
    self._run_pre()
  File "build/bdist.linux-x86_64/egg/vsc/utils/run.py", line 273, in _run_pre
    self._init_process()
  File "build/bdist.linux-x86_64/egg/vsc/utils/run.py", line 367, in _init_process
    self._process = self._process_module.Popen(self._shellcmd, **self._popen_named_args)
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/sandybridge/software/Python/2.7.14-intel-2018a/lib/python2.7/subprocess.py", line 390, in __init__
    errread, errwrite)
  File "/user/home/gent/vsc400/vsc40023/eb_phanpyscratch/CO7/sandybridge/software/Python/2.7.14-intel-2018a/lib/python2.7/subprocess.py", line 1025, in _execute_child
    raise child_exception
TypeError: execv() arg 2 must contain only strings
```

The `CmdList` class should help with avoiding such situations...