### PR TITLE
fix trivial style fixes that prospector now complains about

### DIFF
--- a/lib/vsc/utils/affinity.py
+++ b/lib/vsc/utils/affinity.py
@@ -126,7 +126,7 @@ class cpu_set_t(ctypes.Structure):
                 self.log.raiseException("convert_hr_bits: end is lower then start in '%s'" % rng)
             elif indices[0] < 0:
                 self.log.raiseException("convert_hr_bits: negative start in '%s'" % rng)
-            elif indices[1] > CPU_SETSIZE + 1 :  # also covers start, since end > start
+            elif indices[1] > CPU_SETSIZE + 1:  # also covers start, since end > start
                 self.log.raiseException("convert_hr_bits: end larger then max %s in '%s'" % (CPU_SETSIZE, rng))
 
             self.cpus[indices[0]:indices[1] + 1] = [1] * (indices[1] + 1 - indices[0])
@@ -164,7 +164,7 @@ class cpu_set_t(ctypes.Structure):
         nr_cpus = len(cpus_list)
         if  nr_cpus > CPU_SETSIZE:
             self.log.warning("set_cpus: length cpu list %s is larger then cpusetsize %s. Truncating to cpusetsize" %
-                           (nr_cpus , CPU_SETSIZE))
+                           (nr_cpus, CPU_SETSIZE))
             cpus_list = cpus_list[:CPU_SETSIZE]
         elif nr_cpus < CPU_SETSIZE:
             cpus_list.extend([0] * (CPU_SETSIZE - nr_cpus))

--- a/lib/vsc/utils/docs.py
+++ b/lib/vsc/utils/docs.py
@@ -46,7 +46,7 @@ def mk_rst_table(titles, columns):
         raise LengthNotEqualException, msg
     table = []
     tmpl = []
-    line= []
+    line = []
 
     # figure out column widths
     for i, title in enumerate(titles):

--- a/lib/vsc/utils/optcomplete.py
+++ b/lib/vsc/utils/optcomplete.py
@@ -356,7 +356,7 @@ def guess_first_nonoption(gparser, subcmds_map):
     the subcommand."""
 
     gparser = copy.deepcopy(gparser)
-    def print_usage_nousage (self, *args, **kwargs): # pylint: disable=unused-argument
+    def print_usage_nousage(self, *args, **kwargs): # pylint: disable=unused-argument
         pass
     gparser.print_usage = print_usage_nousage
 

--- a/lib/vsc/utils/wrapper.py
+++ b/lib/vsc/utils/wrapper.py
@@ -1,6 +1,6 @@
 ### External compatible license
 """
-This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 Unported License 
+This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 Unported License
 with attribution required
 
 Original code by http://stackoverflow.com/users/416467/kindall from answer 4 of

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '2.8.0',
+    'version': '2.8.1',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger


### PR DESCRIPTION
tests fail on top of https://github.com/hpcugent/vsc-install/pull/88 because of these trivial style issues

not sure why these didn't pop up before...

```
FAIL: test_prospector (vsc.install.commontest.CommonTest)
Run prospector.run.main, but apply white/blacklists to the results
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Volumes/work/vsc-install/lib/vsc/install/commontest.py", line 244, in test_prospector
    self.assertFalse(failures, "prospector failures: %s" % pprint.pformat(failures))
AssertionError: [{'source': 'pylint', 'message': 'No space allowed before bracket\n    def print_usage_nousage (self, *args, **kwargs): # pylint: disable=unused-argument\n                            ^', 'code': 'bad-whitespace', 'location': {'function': None, 'path': u'/Volumes/work/vsc-base/lib/vsc/utils/optcomplete.py', 'line': 359, 'character': 0, 'module': 'vsc.utils.optcomplete'}}, {'source': 'pylint', 'message': 'No space allowed before :\n            elif indices[1] > CPU_SETSIZE + 1 :  # also covers start, since end > start\n                                              ^', 'code': 'bad-whitespace', 'location': {'function': None, 'path': u'/Volumes/work/vsc-base/lib/vsc/utils/affinity.py', 'line': 129, 'character': 0, 'module': 'vsc.utils.affinity'}}, {'source': 'pylint', 'message': 'No space allowed before comma\n                           (nr_cpus , CPU_SETSIZE))\n                                    ^', 'code': 'bad-whitespace', 'location': {'function': None, 'path': u'/Volumes/work/vsc-base/lib/vsc/utils/affinity.py', 'line': 167, 'character': 0, 'module': 'vsc.utils.affinity'}}, {'source': 'pylint', 'message': 'Exactly one space required before assignment\n    line= []\n        ^', 'code': 'bad-whitespace', 'location': {'function': None, 'path': u'/Volumes/work/vsc-base/lib/vsc/utils/docs.py', 'line': 49, 'character': 0, 'module': 'vsc.utils.docs'}}, {'source': 'pylint', 'message': 'Trailing whitespace', 'code': 'trailing-whitespace', 'location': {'function': None, 'path': u'/Volumes/work/vsc-base/lib/vsc/utils/wrapper.py', 'line': 3, 'character': 0, 'module': 'vsc.utils.wrapper'}}] is not false : prospector failures: [{'code': 'bad-whitespace',
  'location': {'character': 0,
               'function': None,
               'line': 359,
               'module': 'vsc.utils.optcomplete',
               'path': u'/Volumes/work/vsc-base/lib/vsc/utils/optcomplete.py'},
  'message': 'No space allowed before bracket\n    def print_usage_nousage (self, *args, **kwargs): # pylint: disable=unused-argument\n                            ^',
  'source': 'pylint'},
 {'code': 'bad-whitespace',
  'location': {'character': 0,
               'function': None,
               'line': 129,
               'module': 'vsc.utils.affinity',
               'path': u'/Volumes/work/vsc-base/lib/vsc/utils/affinity.py'},
  'message': 'No space allowed before :\n            elif indices[1] > CPU_SETSIZE + 1 :  # also covers start, since end > start\n                                              ^',
  'source': 'pylint'},
 {'code': 'bad-whitespace',
  'location': {'character': 0,
               'function': None,
               'line': 167,
               'module': 'vsc.utils.affinity',
               'path': u'/Volumes/work/vsc-base/lib/vsc/utils/affinity.py'},
  'message': 'No space allowed before comma\n                           (nr_cpus , CPU_SETSIZE))\n                                    ^',
  'source': 'pylint'},
 {'code': 'bad-whitespace',
  'location': {'character': 0,
               'function': None,
               'line': 49,
               'module': 'vsc.utils.docs',
               'path': u'/Volumes/work/vsc-base/lib/vsc/utils/docs.py'},
  'message': 'Exactly one space required before assignment\n    line= []\n        ^',
  'source': 'pylint'},
 {'code': 'trailing-whitespace',
  'location': {'character': 0,
               'function': None,
               'line': 3,
               'module': 'vsc.utils.wrapper',
               'path': u'/Volumes/work/vsc-base/lib/vsc/utils/wrapper.py'},
  'message': 'Trailing whitespace',
  'source': 'pylint'}]
```