### PR TITLE
check whether /dev/log exists before logging to it in logToDevLog

### DIFF
--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -724,11 +724,13 @@ def _getSysLogFacility(name=None):
 
 def logToDevLog(enable=True, name=None, handler=None):
     """Log to syslog through /dev/log"""
+
+    syslogoptions = {'facility': _getSysLogFacility()}
+
     devlog = '/dev/log'
-    syslogoptions = {
-        'address': devlog,
-        'facility': _getSysLogFacility()
-    }
+    if os.path.exists(devlog):
+        syslogoptions['address'] = devlog
+
     return _logToSomething(logging.handlers.SysLogHandler,
                            syslogoptions, 'logtodevlog', enable=enable, name=name, handler=handler)
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '2.8.1',
+    'version': '2.8.2',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger

--- a/test/fancylogger.py
+++ b/test/fancylogger.py
@@ -667,6 +667,12 @@ class EnvToBooleanTest(TestCase):
     def test_env_to_boolean_undef_with_default(self):
         self.assertEqual(fancylogger._env_to_boolean(self.testvar_undef, 42), 42)
 
+    def test_log_to_syslog(self):
+        fancylogger.logToDevLog(True)
+        fancylogger.setLogLevelInfo()
+        logging.warn("test_log_to_syslog - This is just a test, nothing to be alarm about")
+        logging.warn("test_log_to_syslog - Another test, please ignore")
+
     def tearDown(self):
         if self.testvar in os.environ:
             del os.environ[self.testvar]


### PR DESCRIPTION
This mainly facilitates testing on systems where there's no `/dev/log` present.

Without this, `logToDevLog` fails in mysterious ways, without a trace of what the actual problem is (missing `/dev/log`):

```
python -c "from vsc.utils.fancylogger import logToDevLog; logToDevLog()"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Volumes/work/vsc-base/lib/vsc/utils/fancylogger.py", line 733, in logToDevLog
    syslogoptions, 'logtodevlog', enable=enable, name=name, handler=handler)
  File "/Volumes/work/vsc-base/lib/vsc/utils/fancylogger.py", line 648, in _logToSomething
    handler = handlerclass(**handleropts)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/handlers.py", line 762, in __init__
    self._connect_unixsocket(address)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/handlers.py", line 790, in _connect_unixsocket
    self.socket.connect(address)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
socket.error: [Errno 2] No such file or directory
```

If `/dev/log` is not there, logging continues just fine to the default syslog location.