### PR TITLE
actually return headers when http method is HEAD

### DIFF
--- a/bin/logdaemon.py
+++ b/bin/logdaemon.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2011-2018 Ghent University
+# Copyright 2011-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/__init__.py
+++ b/lib/vsc/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2018 Ghent University
+# Copyright 2015-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/__init__.py
+++ b/lib/vsc/utils/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2018 Ghent University
+# Copyright 2015-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/affinity.py
+++ b/lib/vsc/utils/affinity.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/dateandtime.py
+++ b/lib/vsc/utils/dateandtime.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/docs.py
+++ b/lib/vsc/utils/docs.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2018 Ghent University
+# Copyright 2015-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/exceptions.py
+++ b/lib/vsc/utils/exceptions.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2018 Ghent University
+# Copyright 2015-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2018 Ghent University
+# Copyright 2011-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2018 Ghent University
+# Copyright 2011-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/mail.py
+++ b/lib/vsc/utils/mail.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/missing.py
+++ b/lib/vsc/utils/missing.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/patterns.py
+++ b/lib/vsc/utils/patterns.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/rest.py
+++ b/lib/vsc/utils/rest.py
@@ -174,11 +174,14 @@ class Client(object):
         # TODO: in recent python: Context manager
         conn = self.get_connection(method, url, body, headers)
         status = conn.code
-        body = conn.read()
-        try:
-            pybody = json.loads(body)
-        except ValueError:
-            pybody = body
+        if method == self.HEAD:
+            pybody = conn.headers
+        else:
+            body = conn.read()
+            try:
+                pybody = json.loads(body)
+            except ValueError:
+                pybody = body
         fancylogger.getLogger().debug('reponse len: %s ', len(pybody))
         conn.close()
         return status, pybody

--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2018 Ghent University
+# Copyright 2009-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/utils/testing.py
+++ b/lib/vsc/utils/testing.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2018 Ghent University
+# Copyright 2014-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '2.8.3',
+    'version': '2.8.4',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger

--- a/test/00-import.py
+++ b/test/00-import.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2017 Ghent University
+# Copyright 2016-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,16 +1,28 @@
-##
-# Copyright 2012-2015 Ghent University
 #
-# This file is part of ,
+# Copyright 2012-2019 Ghent University
+#
+# This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
 # with support of Ghent University (http://ugent.be/hpc),
-# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
-# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# the Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# All rights reserved.
+# https://github.com/hpcugent/vsc-base
 #
-##
+# vsc-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Library General Public License as
+# published by the Free Software Foundation, either version 2 of
+# the License, or (at your option) any later version.
+#
+# vsc-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public License
+# along with vsc-base. If not, see <http://www.gnu.org/licenses/>.
+#
 """
 Init
 """

--- a/test/asyncprocess.py
+++ b/test/asyncprocess.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/dateandtime.py
+++ b/test/dateandtime.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/docs.py
+++ b/test/docs.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2017 Ghent University
+# Copyright 2015-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/exceptions.py
+++ b/test/exceptions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2015-2017 Ghent University
+# Copyright 2015-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/fancylogger.py
+++ b/test/fancylogger.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/generaloption.py
+++ b/test/generaloption.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/missing.py
+++ b/test/missing.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/optcomplete.py
+++ b/test/optcomplete.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/rest.py
+++ b/test/rest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/rest.py
+++ b/test/rest.py
@@ -71,8 +71,10 @@ class RestClientTest(TestCase):
 
     def test_request_methods(self):
         """Test all request methods"""
-        status, body = self.client.head()
+        status, headers = self.client.head()
         self.assertEqual(status, 200)
+        self.assertTrue(headers)
+        self.assertIn('X-GitHub-Media-Type', headers)
         try:
             status, body = self.client.user.emails.post(body='jens.timmerman@ugent.be')
             self.assertTrue(False, 'posting to unauthorized endpoint did not trhow a http error')

--- a/test/rest.py
+++ b/test/rest.py
@@ -74,7 +74,7 @@ class RestClientTest(TestCase):
         status, headers = self.client.head()
         self.assertEqual(status, 200)
         self.assertTrue(headers)
-        self.assertIn('X-GitHub-Media-Type', headers)
+        self.assertTrue('X-GitHub-Media-Type' in headers)
         try:
             status, body = self.client.user.emails.post(body='jens.timmerman@ugent.be')
             self.assertTrue(False, 'posting to unauthorized endpoint did not trhow a http error')

--- a/test/run.py
+++ b/test/run.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/runtests/qa.py
+++ b/test/runtests/qa.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2017 Ghent University
+# Copyright 2016-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/runtests/simple.py
+++ b/test/runtests/simple.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2017 Ghent University
+# Copyright 2016-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/runtests/simple_option.py
+++ b/test/runtests/simple_option.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2011-2017 Ghent University
+# Copyright 2011-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/sandbox/testpkg/__init__.py
+++ b/test/sandbox/testpkg/__init__.py
@@ -1,4 +1,29 @@
 #
+# Copyright 2019-2019 Ghent University
+#
+# This file is part of vsc-base,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# the Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/hpcugent/vsc-base
+#
+# vsc-base is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Library General Public License as
+# published by the Free Software Foundation, either version 2 of
+# the License, or (at your option) any later version.
+#
+# vsc-base is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public License
+# along with vsc-base. If not, see <http://www.gnu.org/licenses/>.
+#
+#
 # Copyright 2016-2017 Ghent University
 #
 # This file is part of vsc-base,

--- a/test/sandbox/testpkg/testmodule.py
+++ b/test/sandbox/testpkg/testmodule.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/sandbox/testpkg/testmodulebis.py
+++ b/test/sandbox/testpkg/testmodulebis.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/testing.py
+++ b/test/testing.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/wrapper.py
+++ b/test/wrapper.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2019 Ghent University
 #
 # This file is part of vsc-base,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),


### PR DESCRIPTION
the message body when using the http HEAD method is empty, this change allows the head() method to actually return the headers (https://github.com/easybuilders/easybuild-framework/pull/2553#issuecomment-458456195)