### PR TITLE
take into account slightly different output with bash 4.x in test_noshell_glob

### DIFF
--- a/test/run.py
+++ b/test/run.py
@@ -108,7 +108,8 @@ class TestRun(TestCase):
     def test_noshell_glob(self):
         ec, output = run('ls test/sandbox/testpkg/*')
         self.assertTrue(ec > 0)
-        self.assertTrue('test/sandbox/testpkg/*: No such file or directory' in output)
+        regex = re.compile(r"'?test/sandbox/testpkg/\*'?: No such file or directory")
+        self.assertTrue(regex.search(output), "Pattern '%s' found in: %s" % (regex.pattern, output))
         ec, output = run_simple(['ls','test/sandbox/testpkg/*'])
         self.assertEqual(ec, 0)
         self.assertTrue(all(x in output.lower() for x in ['__init__.py', 'testmodule.py', 'testmodulebis.py']))


### PR DESCRIPTION
In bash 4.x, the error message looks like:

```
cannot access 'test/sandbox/testpkg/*': No such file or directory
```

while in bash 3.x it looks like:

```
test/sandbox/testpkg/*: No such file or directory
```

(i.e. no single quotes around it)

No need for a version bump imho, since this only touches the tests...