### PR TITLE
skip tests that talk to GitHub API when no GitHub token is available

### DIFF
--- a/test/rest.py
+++ b/test/rest.py
@@ -60,6 +60,10 @@ class RestClientTest(TestCase):
 
     def test_client(self):
         """Do a test api call"""
+        if GITHUB_TOKEN is None:
+            print("Skipping test_client, since no GitHub token is available")
+            return
+
         status, body = self.client.repos[GITHUB_USER][GITHUB_REPO].contents.a_directory['a_file.txt'].get()
         self.assertEqual(status, 200)
         # dGhpcyBpcyBhIGxpbmUgb2YgdGV4dAo= == 'this is a line of text' in base64 encoding
@@ -71,6 +75,10 @@ class RestClientTest(TestCase):
 
     def test_request_methods(self):
         """Test all request methods"""
+        if GITHUB_TOKEN is None:
+            print("Skipping test_request_methods, since no GitHub token is available")
+            return
+
         status, headers = self.client.head()
         self.assertEqual(status, 200)
         self.assertTrue(headers)


### PR DESCRIPTION
I've added a GitHub token in Travis using the `$VSC_GITHUB_TOKEN` environment variable, but this is not made available for pull requests (since then anyone could steal the token by just printing it via a PR).

Hence, we should skip the `rest` tests when no GitHub token is available, to avoid that the tests fail due to GitHub rate limiting...

(only changes in tests, so no need to bump the version imho)