### PR TITLE
run tests with both Python 2.7 & 3.6 via tox (HPC-7603)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
-language: python
-python:
-  - "2.7"
-install:
-  - easy_install vsc-install
+dist: bionic
+language: generic
+addons:
+  apt:
+    packages:
+      - python2.7
+      - python3.6
+before_install:
+    # virtualenv 16.0.0 upgraded vendored pip to 10.0.1,
+    # which includes a sufficiently recent setuptools to avoid
+    # hitting the problem described in https://github.com/pypa/setuptools/issues/1282
+    - pip install --user 'virtualenv>=16.0.0' tox
 script:
-  # 'hpcugent' is a mandatory remote for setup.py to work (because of vsc-install)
+  # 'hpcugent' is a mandatory remote for setup.py to work (because of get_name_url)
   - git remote add hpcugent https://github.com/hpcugent/vsc-base.git
-  - python setup.py test
+  - tox -v -c tox.ini

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,14 +1,14 @@
-#!/usr/bin/env groovy
- 
+// Jenkinsfile: scripted Jenkins pipefile
+// This file was automatically generated using 'python -m vsc.install.ci'
+// DO NOT EDIT MANUALLY
+
 node {
-    stage 'Checkout'
-    checkout scm
-    stage 'install dependencies'
-    sh "wget -O ez_setup.py https://bootstrap.pypa.io/ez_setup.py"
-    sh "python ez_setup.py --user"
-    sh "python -m easy_install -U --user vsc-install"
-    stage 'cleanup'
-    sh "git clean -fd"
-    stage 'test'
-    sh "python setup.py test"
+    stage('checkout git') {
+        checkout scm
+    }
+    stage('test') {
+        sh 'python2.7 -V'
+        sh 'python -m easy_install -U --user tox'
+        sh 'export PATH=$HOME/.local/bin:$PATH && tox -v -c tox.ini'
+    }
 }

--- a/lib/vsc/utils/optcomplete.py
+++ b/lib/vsc/utils/optcomplete.py
@@ -633,7 +633,7 @@ def gen_cmdline(cmd_list, partial, shebang=True):
     env.append("COMP_CWORD=%s" % cmd_list.index(partial))
 
     if not shebang:
-        env.append(sys.executable)
+        env.append(shell_quote(sys.executable))
 
     # add script
     env.append('"%s"' % cmd_list[0])

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '2.9.3',
+    'version': '2.9.4',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger

--- a/test/fancylogger.py
+++ b/test/fancylogger.py
@@ -65,9 +65,11 @@ MSGRE_TPL = r"%%s.*%s" % MSG
 
 def _get_tty_stream():
     """Try to open and return a stream connected to a TTY device."""
-    if os.isatty(sys.stdout.fileno()):
+    # sys.stdout/sys.stderr may be a StringIO object, which does not have fileno
+    # this happens when running the tests in a virtualenv (e.g. via tox)
+    if hasattr(sys.stdout, 'fileno') and os.isatty(sys.stdout.fileno()):
         return sys.stdout
-    elif os.isatty(sys.stderr.fileno()):
+    elif hasattr(sys.stderr, 'fileno') and os.isatty(sys.stderr.fileno()):
         return sys.stderr
     else:
         if 'TTY' in os.environ:

--- a/test/fancylogger.py
+++ b/test/fancylogger.py
@@ -313,19 +313,28 @@ class FancyLoggerTest(TestCase):
 
         logger = fancylogger.getLogger('fail_test')
         self.assertErrorRegex(Exception, 'failtest', test123, Exception, 'failtest')
-        self.assertTrue(re.match("^WARNING.*HIT.*failtest\n.*in test123.*$", open(self.logfn, 'r').read(), re.M))
+
+        regex = re.compile("^WARNING.*HIT.*failtest\n.*in test123.*$", re.M)
+        txt = open(self.logfn, 'r').read()
+        self.assertTrue(regex.match(txt), "Pattern '%s' matches '%s'" % (regex.pattern, txt))
 
         open(self.logfn, 'w')
         fancylogger.FancyLogger.RAISE_EXCEPTION_CLASS = KeyError
         logger = fancylogger.getLogger('fail_test')
         self.assertErrorRegex(KeyError, 'failkeytest', test123, KeyError, 'failkeytest')
-        self.assertTrue(re.match("^WARNING.*HIT.*'failkeytest'\n.*in test123.*$", open(self.logfn, 'r').read(), re.M))
+
+        regex = re.compile("^WARNING.*HIT.*'failkeytest'\n.*in test123.*$", re.M)
+        txt = open(self.logfn, 'r').read()
+        self.assertTrue(regex.match(txt), "Pattern '%s' matches '%s'" % (regex.pattern, txt))
 
         open(self.logfn, 'w')
         fancylogger.FancyLogger.RAISE_EXCEPTION_LOG_METHOD = lambda c, msg: c.warning(msg)
         logger = fancylogger.getLogger('fail_test')
         self.assertErrorRegex(AttributeError, 'attrtest', test123, AttributeError, 'attrtest')
-        self.assertTrue(re.match("^WARNING.*HIT.*attrtest\n.*in test123.*$", open(self.logfn, 'r').read(), re.M))
+
+        regex = re.compile("^WARNING.*HIT.*attrtest\n.*in test123.*$", re.M)
+        txt = open(self.logfn, 'r').read()
+        self.assertTrue(regex.match(txt), "Pattern '%s' matches '%s'" % (regex.pattern, txt))
 
     def _stream_stdouterr(self, isstdout=True, expect_match=True):
         """Log to stdout or stderror, check stdout or stderror"""
@@ -468,8 +477,8 @@ class FancyLoggerTest(TestCase):
         self.assertTrue(msg in stringfile.getvalue(),
                         msg="'%s' in '%s'" % (msg, stringfile.getvalue()))
 
-
-    def test_fancylogger_as_rootlogger_logging(self):
+    # make sure this test runs last, since it may mess up other tests (like test_raiseException)
+    def test_zzz_fancylogger_as_rootlogger_logging(self):
         """
         Test if just using import logging, logging with logging uses fancylogger
         after setting the root logger
@@ -482,7 +491,6 @@ class FancyLoggerTest(TestCase):
                          msg='logging.root is the root logger')
         self.assertFalse(isinstance(logging.root, fancylogger.FancyLogger),
                          msg='logging.root is not a FancyLogger')
-
 
         stringfile = StringIO()
         sys.stderr = stringfile

--- a/test/run.py
+++ b/test/run.py
@@ -28,20 +28,17 @@ Tests for the vsc.utils.run module.
 
 @author: Stijn De Weirdt (Ghent University)
 """
-import pkgutil
-import logging
 import os
 import re
-import stat
 import sys
 import tempfile
 import time
 import shutil
-from unittest import TestLoader, main
 
 # Uncomment when debugging, cannot enable permanetnly, messes up tests that toggle debugging
 #logging.basicConfig(level=logging.DEBUG)
 
+from vsc.utils.missing import shell_quote
 from vsc.utils.run import (
     CmdList, run, run_simple, asyncloop, run_asyncloop,
     run_timeout, RunTimeout,
@@ -161,14 +158,14 @@ class TestRun(TestCase):
         self.assertTrue('(foo bar)' in output)
 
         # to run Python command, it's required to use the right executable (Python shell rather than default)
-        ec, output = run("""%s -c 'print ("foo")'""" % sys.executable)
+        python_cmd = shell_quote(sys.executable)
+        ec, output = run("""%s -c 'print ("foo")'""" % python_cmd)
         self.assertEqual(ec, 0)
         self.assertTrue('foo' in output)
 
         ec, output = run([sys.executable, '-c', 'print ("foo")'])
         self.assertEqual(ec, 0)
         self.assertTrue('foo' in output)
-
 
     def test_timeout(self):
         timeout = 3

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+# tox.ini: configuration file for tox
+# This file was automatically generated using 'python -m vsc.install.ci'
+# DO NOT EDIT MANUALLY
+
+[tox]
+envlist = py27,py36
+skipsdist = true
+skip_missing_interpreters = true
+
+[testenv]
+commands_pre = python -m easy_install -U vsc-install
+commands = python setup.py test
+passenv = USER
+
+[testenv:py36]
+ignore_outcome = true


### PR DESCRIPTION
Both `Jenkinsfile` & `tox.ini` are automatically generated via `python -m vsc.install.ci -f` (cfr. https://github.com/hpcugent/vsc-install/pull/114)

Tests with Python 3.6 are allowed to fail for now in Travis (and will fail in Jenkins because `python3.6` is missing, for now).