### PR TITLE
fix resource leak by calling close() after running command in subprocess in set_columns() function provided by generaloption

### DIFF
--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -66,7 +66,9 @@ def set_columns(cols=None):
         stty = '/usr/bin/stty'
         if os.path.exists(stty):
             try:
-                cols = int(os.popen('%s size 2>/dev/null' % stty).read().strip().split(' ')[1])
+                proc = os.popen('%s size 2>/dev/null' % stty)
+                cols = int(proc.read().strip().split(' ')[1])
+                proc.close()
             except (AttributeError, IndexError, OSError, ValueError):
                 # do nothing
                 pass

--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -35,6 +35,7 @@ import inspect
 import operator
 import os
 import re
+import shutil
 import sys
 import textwrap
 from functools import reduce
@@ -47,11 +48,12 @@ from vsc.utils.dateandtime import date_parser, datetime_parser
 from vsc.utils.docs import mk_rst_table
 from vsc.utils.fancylogger import getLogger, setroot, setLogLevel, getDetailsLogLevels
 from vsc.utils.missing import nub, shell_quote
-from vsc.utils.py2vs3 import StringIO, configparser, is_string
+from vsc.utils.py2vs3 import StringIO, configparser, is_py_ver, is_string
 from vsc.utils.optcomplete import autocomplete, CompleterOption
 
 
 HELP_OUTPUT_FORMATS = ['', 'rst', 'short', 'config']
+STTY = '/usr/bin/stty'
 
 
 def set_columns(cols=None):
@@ -63,10 +65,11 @@ def set_columns(cols=None):
         return
 
     if cols is None:
-        stty = '/usr/bin/stty'
-        if os.path.exists(stty):
+        if is_py_ver(3, 3):
+            cols, _ = shutil.get_terminal_size()
+        elif os.path.exists(STTY):
             try:
-                proc = os.popen('%s size 2>/dev/null' % stty)
+                proc = os.popen('%s size 2>/dev/null' % STTY)
                 cols = int(proc.read().strip().split(' ')[1])
                 proc.close()
             except (AttributeError, IndexError, OSError, ValueError):

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '3.0.0',
+    'version': '3.0.1',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger

--- a/test/run.py
+++ b/test/run.py
@@ -186,7 +186,8 @@ class TestRun(TestCase):
             """ Check For the existence of a unix pid. """
             try:
                 os.kill(pid, 0)
-            except OSError:
+            except OSError as err:
+                sys.stderr.write("check_pid in test_timeout: %s\n" % err)
                 return False
             else:
                 return True


### PR DESCRIPTION
`vsc-config` tests are failing with Python 3 because warnings like this are popping up in stderr:

```
/usr/lib64/python3.6/subprocess.py:786: ResourceWarning: subprocess 7342 is still running
```

It's not entirely clear where they're coming from, but it may be the `get_columns` function which is called every time a `GeneralOption` instance is created, since it is running a (short lived) subprocess without properly cleaning up afterwards...