### PR TITLE
fix resource warning in Python 3 for vsc.utils.run

### DIFF
--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -396,7 +396,7 @@ class Run(object):
 
     def _cleanup_process(self):
         """Cleanup any leftovers from the process"""
-        if self._process.stdout is not None:
+        if self._process.stdout is not None and not self._process.stdout.closed:
             try:
                 self._process.stdout.close()
             except OSError as err:

--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -396,10 +396,11 @@ class Run(object):
 
     def _cleanup_process(self):
         """Cleanup any leftovers from the process"""
-        try:
-            self._process.stdout.close()
-        except OSError as err:
-            self.log.raiseException("_cleanup_process: failed to close stdout of the process: %s" % err)
+        if self._process.stdout is not None:
+            try:
+                self._process.stdout.close()
+            except OSError as err:
+                self.log.raiseException("_cleanup_process: failed to close stdout of the process: %s" % err)
 
     def _read_process(self, readsize=None):
         """Read from process, return out"""

--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -396,7 +396,10 @@ class Run(object):
 
     def _cleanup_process(self):
         """Cleanup any leftovers from the process"""
-        pass
+        try:
+            self._process.stdout.close()
+        except OSError:
+            self.log.raiseException("_cleanup_process: failed to close stdout of the process")
 
     def _read_process(self, readsize=None):
         """Read from process, return out"""

--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -398,8 +398,8 @@ class Run(object):
         """Cleanup any leftovers from the process"""
         try:
             self._process.stdout.close()
-        except OSError:
-            self.log.raiseException("_cleanup_process: failed to close stdout of the process")
+        except OSError as err:
+            self.log.raiseException("_cleanup_process: failed to close stdout of the process: %s" % err)
 
     def _read_process(self, readsize=None):
         """Read from process, return out"""

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '3.0.4',
+    'version': '3.0.5',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger


### PR DESCRIPTION
to avoid errors like `lib/jobcli/utils.py:171: ResourceWarning: unclosed file <_io.BufferedReader name=5>` we need to close the stdout from the process.