### PR TITLE
ensure input to stdin.write is a bytestring in Python 3

### DIFF
--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -74,7 +74,7 @@ import sys
 import time
 
 from vsc.utils.fancylogger import getLogger
-from vsc.utils.py2vs3 import ensure_ascii_string, is_string
+from vsc.utils.py2vs3 import ensure_ascii_string, is_py3, is_string
 
 PROCESS_MODULE_ASYNCPROCESS_PATH = 'vsc.utils.asyncprocess'
 PROCESS_MODULE_SUBPROCESS_PATH = 'subprocess'
@@ -372,8 +372,13 @@ class Run(object):
     def _init_input(self):
         """Handle input, if any in a simple way"""
         if self.input is not None:  # allow empty string (whatever it may mean)
+            # in Python 3, stdin.write requires a bytestring
+            if is_py3():
+                inp = bytes(self.input, encoding='utf-8')
+            else:
+                inp = self.input
             try:
-                self._process.stdin.write(self.input)
+                self._process.stdin.write(inp)
             except Exception:
                 self.log.raiseException("_init_input: Failed write input %s to process" % self.input)
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '3.1.0',
+    'version': '3.1.1',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger

--- a/test/run.py
+++ b/test/run.py
@@ -163,6 +163,24 @@ class TestRun(TestCase):
             self.assertEqual(output, msg + '\n')
             self.assertEqual(output, stdout)
 
+    def test_noshell_async_stdout_stdin(self):
+
+        inp = "testing, 1, 2, 3"
+
+        self.mock_stderr(True)
+        self.mock_stdout(True)
+        ec, output = async_to_stdout('/bin/cat', input=inp)
+        stderr, stdout = self.get_stderr(), self.get_stdout()
+        self.mock_stderr(False)
+        self.mock_stdout(False)
+
+        # there should be no output to stderr
+        self.assertFalse(stderr)
+
+        self.assertEqual(ec, 0)
+        self.assertEqual(output, inp)
+        self.assertEqual(output, stdout)
+
     def test_async_stdout_glob(self):
         self.mock_stdout(True)
         ec, output = run_async_to_stdout("/bin/echo ok")


### PR DESCRIPTION
fixes bug triggered by running `clusterbuildrpm` with Python 3:

```
$ python3 bin/clusterbuildrpm.py -Q vsc-cluster-modules
2020-04-22 10:42:31,065 WARNING    RunNoShellAsyncLoop MainThread  _init_input: Failed write input {"repotype": "private", "hosttype": "private", "account": "hpcugent", "branch": "master", "project": "vsc-cluster-modules", "chdir": null, "user": "kehoste", "prefix": null, "tag": "", "ghproject": "vsc-cluster-modules", "queryonly": true} to process (a bytes-like object is required, not 'str'
  File "/Volumes/work/vsc-base/lib/vsc/utils/run.py", line 376, in _init_input
    self._process.stdin.write(self.input)
)
Traceback (most recent call last):
  File "/Volumes/work/vsc-base/lib/vsc/utils/run.py", line 376, in _init_input
    self._process.stdin.write(self.input)
TypeError: a bytes-like object is required, not 'str'
```