### PR TITLE
only create bytestring from string input values before feeding to stdin.write in run.py

### DIFF
--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -373,7 +373,7 @@ class Run(object):
         """Handle input, if any in a simple way"""
         if self.input is not None:  # allow empty string (whatever it may mean)
             # in Python 3, stdin.write requires a bytestring
-            if is_py3():
+            if is_py3() and is_string(self.input):
                 inp = bytes(self.input, encoding='utf-8')
             else:
                 inp = self.input

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '3.1.1',
+    'version': '3.1.2',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger


### PR DESCRIPTION
I overlooked this in #299...

Fixes cases where bytestring is passed as input, basically this problem:

```
>>> x=b'foo'
>>> bytes(x)
b'foo'
>>> bytes(x, encoding='utf-8')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: encoding without a string argument
```

