### PR TITLE
add .eggs* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 setup.cfg
 
 # Packages
-.eggs
+.eggs*
 *.egg
 *.egg-info
 dist

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '3.1.3',
+    'version': '3.1.4',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger


### PR DESCRIPTION
This is required to make the tests pass of anything that depends on vsc-base (required since hpcugent/vsc-install#151 got merged), cfr. test failure in https://github.com/hpcugent/vsc-config/pull/112