### PR TITLE
URL encode the domain and path of URLs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,8 @@ node {
     }
     stage('test') {
         sh 'python2.7 -V'
-        sh 'pip3 install --ignore-installed --user tox'
-        sh 'export PATH=$HOME/.local/bin:$PATH && tox -v -c tox.ini'
+        sh 'pip3 install --ignore-installed --prefix $PWD/.vsc-tox tox'
+        sh 'export PATH=$PWD/.vsc-tox/bin:$PATH && export PYTHONPATH=$PWD/.vsc-tox/lib/python$(python3 -c "import sys; print(\\"%s.%s\\" % sys.version_info[:2])")/site-packages:$PYTHONPATH && tox -v -c tox.ini'
+        sh 'rm -r $PWD/.vsc-tox'
     }
 }

--- a/lib/vsc/utils/py2vs3/py2.py
+++ b/lib/vsc/utils/py2vs3/py2.py
@@ -33,6 +33,7 @@ import ConfigParser as configparser  # noqa
 from cStringIO import StringIO  # noqa
 from pipes import quote  # noqa
 from urllib import urlencode, unquote  # noqa
+from urllib import quote as urlquote  # noqa
 from urllib2 import HTTPError, HTTPSHandler, Request, build_opener, urlopen  # noqa
 from collections import Mapping  # noqa
 

--- a/lib/vsc/utils/py2vs3/py3.py
+++ b/lib/vsc/utils/py2vs3/py3.py
@@ -33,6 +33,7 @@ import pickle  # noqa
 from io import StringIO  # noqa
 from shlex import quote  # noqa
 from urllib.parse import urlencode, unquote  # noqa
+from urllib.parse import quote as urlquote  # noqa
 from urllib.request import HTTPError, HTTPSHandler, Request, build_opener, urlopen  # noqa
 from collections.abc import Mapping  # noqa
 

--- a/lib/vsc/utils/rest.py
+++ b/lib/vsc/utils/rest.py
@@ -42,7 +42,7 @@ from functools import partial
 from future.utils import iteritems
 
 from vsc.utils import fancylogger
-from vsc.utils.py2vs3 import HTTPSHandler, Request, build_opener, urlencode
+from vsc.utils.py2vs3 import HTTPSHandler, Request, build_opener, urlencode, urlquote
 
 
 class Client(object):
@@ -111,7 +111,7 @@ class Client(object):
         Do a http get request on the given url with given headers and parameters
         Parameters is a dictionary that will will be urlencoded
         """
-        url = self._append_slash_to(url) + self.urlencode(params)
+        url = urlquote(self._append_slash_to(url)) + self.urlencode(params)
         return self.request(self.GET, url, None, headers)
 
     def head(self, url, headers=None, **params):
@@ -119,7 +119,7 @@ class Client(object):
         Do a http head request on the given url with given headers and parameters
         Parameters is a dictionary that will will be urlencoded
         """
-        url = self._append_slash_to(url) + self.urlencode(params)
+        url = urlquote(self._append_slash_to(url)) + self.urlencode(params)
         return self.request(self.HEAD, url, None, headers)
 
     def delete(self, url, headers=None, body=None, **params):
@@ -127,7 +127,7 @@ class Client(object):
         Do a http delete request on the given url with given headers, body and parameters
         Parameters is a dictionary that will will be urlencoded
         """
-        url = self._append_slash_to(url) + self.urlencode(params)
+        url = urlquote(self._append_slash_to(url)) + self.urlencode(params)
         return self.request(self.DELETE, url, json.dumps(body), headers, content_type='application/json')
 
     def post(self, url, body=None, headers=None, **params):
@@ -135,7 +135,7 @@ class Client(object):
         Do a http post request on the given url with given body, headers and parameters
         Parameters is a dictionary that will will be urlencoded
         """
-        url = self._append_slash_to(url) + self.urlencode(params)
+        url = urlquote(self._append_slash_to(url)) + self.urlencode(params)
         return self.request(self.POST, url, json.dumps(body), headers, content_type='application/json')
 
     def put(self, url, body=None, headers=None, **params):
@@ -143,7 +143,7 @@ class Client(object):
         Do a http put request on the given url with given body, headers and parameters
         Parameters is a dictionary that will will be urlencoded
         """
-        url = self._append_slash_to(url) + self.urlencode(params)
+        url = urlquote(self._append_slash_to(url)) + self.urlencode(params)
         return self.request(self.PUT, url, json.dumps(body), headers, content_type='application/json')
 
     def patch(self, url, body=None, headers=None, **params):
@@ -151,7 +151,7 @@ class Client(object):
         Do a http patch request on the given url with given body, headers and parameters
         Parameters is a dictionary that will will be urlencoded
         """
-        url = self._append_slash_to(url) + self.urlencode(params)
+        url = urlquote(self._append_slash_to(url)) + self.urlencode(params)
         return self.request(self.PATCH, url, json.dumps(body), headers, content_type='application/json')
 
     def request(self, method, url, body, headers, content_type=None):

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '3.2.0',
+    'version': '3.2.1',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger


### PR DESCRIPTION
This PR adds URL encoding of the domain and path of URLs passed to the rest api. Currently, it only URL encodes the query string of URLs. However, it is possible that the rest client receives non conformant URLs and those should be encoded as well to avoid unnecessary exceptions from `urllib`.

Specifically, this is an issue with group names in the VSC account page that have white spaces, for instance _leuvenall-fluent group_, as those names can be part of the path of URLs. The tool `sync_django_ldap` from `vsc-administration` fails to complete the LDAP sync due to this issue.