### PR TITLE
Add TemporaryDirectory to py2vs3

### DIFF
--- a/lib/vsc/utils/py2vs3/py2.py
+++ b/lib/vsc/utils/py2vs3/py2.py
@@ -76,7 +76,7 @@ class TemporaryDirectory(object):
     in it are removed.
     """
 
-    def __init__(self, suffix="", prefix="tmp", dir=None):
+    def __init__(self, suffix="", prefix="tmp", dir=None):  # noqa
         self._closed = False
         self.name = None # Handle mkdtemp raising an exception
         self.name = mkdtemp(suffix, prefix, dir)

--- a/lib/vsc/utils/py2vs3/py2.py
+++ b/lib/vsc/utils/py2vs3/py2.py
@@ -30,8 +30,10 @@ Utility functions to help with keeping the codebase compatible with both Python 
 """
 import cPickle as pickle  # noqa
 import ConfigParser as configparser  # noqa
+import os  # noqa
 from cStringIO import StringIO  # noqa
 from pipes import quote  # noqa
+from tempfile import mkdtemp  # noqa
 from urllib import urlencode, unquote  # noqa
 from urllib2 import HTTPError, HTTPSHandler, Request, build_opener, urlopen  # noqa
 from collections import Mapping  # noqa
@@ -59,3 +61,72 @@ def ensure_ascii_string(value):
         value = str(value)
 
     return value
+
+# https://stackoverflow.com/questions/19296146/tempfile-temporarydirectory-context-manager-in-python-2-7
+
+class TemporaryDirectory(object):
+    """Create and return a temporary directory.  This has the same
+    behavior as mkdtemp but can be used as a context manager.  For
+    example:
+
+        with TemporaryDirectory() as tmpdir:
+            ...
+
+    Upon exiting the context, the directory and everything contained
+    in it are removed.
+    """
+
+    def __init__(self, suffix="", prefix="tmp", dir=None):
+        self._closed = False
+        self.name = None # Handle mkdtemp raising an exception
+        self.name = mkdtemp(suffix, prefix, dir)
+
+    def __repr__(self):
+        return "<{} {!r}>".format(self.__class__.__name__, self.name)
+
+    def __enter__(self):
+        return self.name
+
+    def cleanup(self):
+        if self.name and not self._closed:
+            self._rmtree(self.name)
+            self._closed = True
+
+    def __exit__(self, exc, value, tb):
+        self.cleanup()
+
+    def __del__(self):
+        # Issue a ResourceWarning if implicit cleanup needed
+        self.cleanup()
+
+    # XXX (ncoghlan): The following code attempts to make
+    # this class tolerant of the module nulling out process
+    # that happens during CPython interpreter shutdown
+    # Alas, it doesn't actually manage it. See issue #10188
+    _listdir = staticmethod(os.listdir)
+    _path_join = staticmethod(os.path.join)
+    _isdir = staticmethod(os.path.isdir)
+    _islink = staticmethod(os.path.islink)
+    _remove = staticmethod(os.remove)
+    _rmdir = staticmethod(os.rmdir)
+
+    def _rmtree(self, path):
+        # Essentially a stripped down version of shutil.rmtree.  We can't
+        # use globals because they may be None'ed out at shutdown.
+        for name in self._listdir(path):
+            fullname = self._path_join(path, name)
+            try:
+                isdir = self._isdir(fullname) and not self._islink(fullname)
+            except OSError:
+                isdir = False
+            if isdir:
+                self._rmtree(fullname)
+            else:
+                try:
+                    self._remove(fullname)
+                except OSError:
+                    pass
+        try:
+            self._rmdir(path)
+        except OSError:
+            pass

--- a/lib/vsc/utils/py2vs3/py3.py
+++ b/lib/vsc/utils/py2vs3/py3.py
@@ -32,6 +32,7 @@ import configparser  # noqa
 import pickle  # noqa
 from io import StringIO  # noqa
 from shlex import quote  # noqa
+from tempfile import TemporaryDirectory  # noqa
 from urllib.parse import urlencode, unquote  # noqa
 from urllib.request import HTTPError, HTTPSHandler, Request, build_opener, urlopen  # noqa
 from collections.abc import Mapping  # noqa

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '3.2.2',
+    'version': '3.2.3',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger

--- a/test/py2vs3.py
+++ b/test/py2vs3.py
@@ -32,7 +32,7 @@ Tests for the vsc.utils.py2vs3 module.
 import os
 import sys
 
-from vsc.utils.py2vs3 import ensure_ascii_string, is_py_ver, is_py2, is_py3, is_string, pickle
+from vsc.utils.py2vs3 import ensure_ascii_string, is_py_ver, is_py2, is_py3, is_string, pickle, TemporaryDirectory
 from vsc.install.testing import TestCase
 
 
@@ -144,3 +144,11 @@ class TestPy2vs3(TestCase):
     def test_urllib_imports(self):
         """Test importing urllib* stuff from py2vs3."""
         from vsc.utils.py2vs3 import HTTPError, HTTPSHandler, Request, build_opener, unquote, urlencode, urlopen
+
+    def test_temporary_directory(self):
+        """Test the class TemporaryDirectory."""
+        with TemporaryDirectory() as temp_dir:
+            path = temp_dir
+            self.assertTrue(os.path.exists(temp_dir), 'Directory created by TemporaryDirectory should work')
+            self.assertTrue(os.path.isdir(temp_dir), 'Directory created by TemporaryDirectory should be a directory')
+        self.assertFalse(os.path.exists(temp_dir), 'Directory created by TemporaryDirectory should cleanup automagically')


### PR DESCRIPTION
This PR ports the class `TemporaryDirectory` to py2. This class creates a temporary directory on initialisation, which gets cleaned up automatically when the object goes out of scope.
This is used in jobcli: https://github.com/hpcugent/jobcli/pull/232/files#r604656426.