### PR TITLE
fix python3.10 collections bug (Mapping moved to collections.abc)

### DIFF
--- a/lib/vsc/utils/missing.py
+++ b/lib/vsc/utils/missing.py
@@ -42,11 +42,11 @@ Various functions that are missing from the default Python library.
 import logging
 import shlex
 import time
-from collections import namedtuple, Mapping
+from collections import namedtuple
 from functools import reduce
 
 from vsc.utils.frozendict import FrozenDict
-from vsc.utils.py2vs3 import quote
+from vsc.utils.py2vs3 import quote, Mapping
 
 
 def nub(list_):

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '3.4.0',
+    'version': '3.4.1',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger


### PR DESCRIPTION
the import is done correctly in `vsc.utils.py2vs3` but not in `missing.py`.