### PR TITLE
handle strings encoding in hash_pass with Python3

### DIFF
--- a/lib/vsc/utils/rest.py
+++ b/lib/vsc/utils/rest.py
@@ -42,7 +42,7 @@ from functools import partial
 from future.utils import iteritems
 
 from vsc.utils import fancylogger
-from vsc.utils.py2vs3 import HTTPSHandler, Request, build_opener, urlencode
+from vsc.utils.py2vs3 import HTTPSHandler, Request, build_opener, is_py3, urlencode
 
 
 class Client(object):
@@ -195,7 +195,18 @@ class Client(object):
     def hash_pass(self, password, username=None):
         if not username:
             username = self.username
-        return 'Basic ' + base64.b64encode('%s:%s' % (username, password)).strip()
+
+        credentials = '%s:%s' % (username, password)
+        if is_py3():
+            # convert credentials into bytes
+            credentials = credentials.encode('utf-8')
+
+        encoded_credentials = base64.b64encode(credentials).strip()
+        if is_py3():
+            # convert back to string
+            encoded_credentials = str(encoded_credentials, 'utf-8')
+
+        return 'Basic ' + encoded_credentials
 
     def get_connection(self, method, url, body, headers):
         if not self.url.endswith('/') and not url.startswith('/'):

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '3.4.3',
+    'version': '3.4.4',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger


### PR DESCRIPTION
`base64.b64encode()` requires byte-like objects in Python 3.