### PR TITLE
decode request response body in python3

### DIFF
--- a/lib/vsc/utils/rest.py
+++ b/lib/vsc/utils/rest.py
@@ -179,6 +179,8 @@ class Client(object):
             pybody = conn.headers
         else:
             body = conn.read()
+            if is_py3():
+                body = body.decode('utf-8')  # byte encoded response
             try:
                 pybody = json.loads(body)
             except ValueError:

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '3.4.4',
+    'version': '3.4.5',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger


### PR DESCRIPTION
In Python 3 [urllib.request](https://docs.python.org/3/library/urllib.request.html) returns a byte object.
