### PR TITLE
Censor X-Auth-Token from logs

### DIFF
--- a/lib/vsc/utils/rest.py
+++ b/lib/vsc/utils/rest.py
@@ -169,6 +169,8 @@ class Client(object):
         # censor contents of 'Authorization' part of header, to avoid leaking tokens or passwords in logs
         headers_censored = copy.deepcopy(headers)
         headers_censored['Authorization'] = '<actual authorization header censored>'
+        if 'X-Auth-Token' in headers_censored:
+            headers_censored['X-Auth-Token'] = '<actual authorization header censored>'
 
         fancylogger.getLogger().debug('cli request: %s, %s, %s, %s', method, url, body, headers_censored)
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '3.4.5',
+    'version': '3.4.6',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger


### PR DESCRIPTION
The X-Auth-Token is used by the REST API of OceanStor.