### PR TITLE
don't call connect if mail host is specified

### DIFF
--- a/lib/vsc/utils/mail.py
+++ b/lib/vsc/utils/mail.py
@@ -108,7 +108,7 @@ class VscMail(object):
 
         If provided, use authentication and TLS.
         """
-        logging.debug("Using mail host %s, mail port %d", self.mail_host, self.mail_port)
+        logging.debug("Using mail host %s, mail port %s", self.mail_host, self.mail_port)
         s = smtplib.SMTP(host=self.mail_host, port=self.mail_port)
 
         if self.smtp_use_starttls:

--- a/lib/vsc/utils/mail.py
+++ b/lib/vsc/utils/mail.py
@@ -115,8 +115,6 @@ class VscMail(object):
             context = ssl.create_default_context()
             s.starttls(context=context)
             logging.debug("Started TLS connection")
-        else:
-            s.connect()
 
         if self.smtp_auth_user and self.smtp_auth_password:
             s.login(user=self.smtp_auth_user, password=self.smtp_auth_password)

--- a/lib/vsc/utils/mail.py
+++ b/lib/vsc/utils/mail.py
@@ -115,6 +115,8 @@ class VscMail(object):
             context = ssl.create_default_context()
             s.starttls(context=context)
             logging.debug("Started TLS connection")
+        elif not self.mail_host:
+            s.connect()
 
         if self.smtp_auth_user and self.smtp_auth_password:
             s.login(user=self.smtp_auth_user, password=self.smtp_auth_password)

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '3.4.7',
+    'version': '3.4.9',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger


### PR DESCRIPTION
as explained in the smtplib docs at https://docs.python.org/3/library/smtplib.html#smtplib.SMTP.connect
"This method is automatically invoked by the constructor if a host is specified during instantiation."

~~the code in mail.py is written in such a way that the mail_host must always be specified, so `connect` is always called automatically.~~

calling `connect` manually (i.e. a second time) causes the process to hang without sending any mails.
