### PR TITLE
Use port 25 with starttls instead of 587 for mailing by default

### DIFF
--- a/lib/vsc/utils/mail.py
+++ b/lib/vsc/utils/mail.py
@@ -72,10 +72,10 @@ class VscMail(object):
     def __init__(
         self,
         mail_host='',
-        mail_port=587,
+        mail_port=25,
         smtp_auth_user=None,
         smtp_auth_password=None,
-        smtp_use_starttls=False,
+        smtp_use_starttls=True,
         mail_config=None):
         """
         - If there is a config file provided, its values take precedence over the arguments passed to __init__

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ _coloredlogs_pkgs = [
 ]
 
 PACKAGE = {
-    'version': '3.4.9',
+    'version': '3.4.10',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     # as long as 1.0.0 is not out, vsc-base should still provide vsc.fancylogger


### PR DESCRIPTION
@itkovian Would this be okay for you?

For us port 587 is not open by default and we rely on 25 with `STARTTLS`.