### PR TITLE
p39: disable empty logging tests

### DIFF
--- a/lib/vsc/utils/generaloption.py
+++ b/lib/vsc/utils/generaloption.py
@@ -798,7 +798,7 @@ class ExtOptionParser(OptionParser):
         epilogprefixtxt += "eg. --some-opt is same as setting %(prefix)s_SOME_OPT in the environment."
         self.epilog.append(epilogprefixtxt % {'prefix': self.envvar_prefix})
 
-        candidates = dict([(k, v) for k, v in os.environ.items() if k.startswith("%s_" % self.envvar_prefix)])
+        candidates = {k: v for k, v in os.environ.items() if k.startswith(f"{self.envvar_prefix}_")}
 
         for opt in self._get_all_options():
             if opt._long_opts is None:

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ag, kh, jt, sdw
 
 PACKAGE = {
-    'version': '3.5.4',
+    'version': '3.5.5',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh],
     'install_requires': [

--- a/test/fancylogger.py
+++ b/test/fancylogger.py
@@ -538,7 +538,7 @@ class FancyLoggerTest(TestCase):
             self.assertEqual(stringfile.getvalue(), '',
                              msg="logging.debug reports nothing when fancylogger loglevel is debug")
         else:
-            self.assertEqual(stringfile.getvalue(), f'DEBUG:root:{msg}:',
+            self.assertEqual(stringfile.getvalue(), f'DEBUG:root:{msg}\n',
                              msg="logging.debug reports something when fancylogger loglevel is debug")
 
         fancylogger.setroot()

--- a/test/fancylogger.py
+++ b/test/fancylogger.py
@@ -532,8 +532,14 @@ class FancyLoggerTest(TestCase):
         msg = 'this is my string'
         logging.debug(msg)
 
-        self.assertEqual(stringfile.getvalue(), '',
+        if sys.version_info < (3,7):
+            # logging stream handling was changed in python 3.7
+            # this is a good thing as messages can no longer go missing
+            self.assertEqual(stringfile.getvalue(), '',
                              msg="logging.debug reports nothing when fancylogger loglevel is debug")
+        else:
+            self.assertEqual(stringfile.getvalue(), msg,
+                             msg="logging.debug reports something when fancylogger loglevel is debug")
 
         fancylogger.setroot()
         self.assertTrue(isinstance(logging.root, fancylogger.FancyLogger),

--- a/test/fancylogger.py
+++ b/test/fancylogger.py
@@ -532,11 +532,8 @@ class FancyLoggerTest(TestCase):
         msg = 'this is my string'
         logging.debug(msg)
 
-        if sys.version_info < (3,7):
-            # logging stream handling was changed in python 3.7
-            # this is a good thing as messages can no longer go missing
-            self.assertEqual(stringfile.getvalue(), '',
-                         msg="logging.debug reports nothing when fancylogger loglevel is debug")
+        self.assertEqual(stringfile.getvalue(), '',
+                             msg="logging.debug reports nothing when fancylogger loglevel is debug")
 
         fancylogger.setroot()
         self.assertTrue(isinstance(logging.root, fancylogger.FancyLogger),

--- a/test/fancylogger.py
+++ b/test/fancylogger.py
@@ -538,7 +538,7 @@ class FancyLoggerTest(TestCase):
             self.assertEqual(stringfile.getvalue(), '',
                              msg="logging.debug reports nothing when fancylogger loglevel is debug")
         else:
-            self.assertEqual(stringfile.getvalue(), f'DEBUG:root:{msg}',
+            self.assertEqual(stringfile.getvalue(), f'DEBUG:root:{msg}:',
                              msg="logging.debug reports something when fancylogger loglevel is debug")
 
         fancylogger.setroot()

--- a/test/fancylogger.py
+++ b/test/fancylogger.py
@@ -532,8 +532,10 @@ class FancyLoggerTest(TestCase):
         msg = 'this is my string'
         logging.debug(msg)
 
-        # fails on python 3.11
-        self.assertEqual(stringfile.getvalue(), '',
+        if sys.version_info < (3,7):
+            # logging stream handling was changed in python 3.7
+            # this is a good thing as messages can no longer go missing
+            self.assertEqual(stringfile.getvalue(), '',
                          msg="logging.debug reports nothing when fancylogger loglevel is debug")
 
         fancylogger.setroot()

--- a/test/fancylogger.py
+++ b/test/fancylogger.py
@@ -532,14 +532,16 @@ class FancyLoggerTest(TestCase):
         msg = 'this is my string'
         logging.debug(msg)
 
+
+
         if sys.version_info < (3,7):
             # logging stream handling was changed in python 3.7
             # this is a good thing as messages can no longer go missing
-            self.assertEqual(stringfile.getvalue(), '',
-                             msg="logging.debug reports nothing when fancylogger loglevel is debug")
+            expected_msg = ''
         else:
-            self.assertEqual(stringfile.getvalue(), f'DEBUG:root:{msg}\n',
-                             msg="logging.debug reports something when fancylogger loglevel is debug")
+            expected_msg = f'DEBUG:root:{msg}\n'
+        self.assertEqual(stringfile.getvalue(), expected_msg,
+                         msg="logging.debug reports expected message (or not) when fancylogger loglevel is debug")
 
         fancylogger.setroot()
         self.assertTrue(isinstance(logging.root, fancylogger.FancyLogger),

--- a/test/fancylogger.py
+++ b/test/fancylogger.py
@@ -538,7 +538,7 @@ class FancyLoggerTest(TestCase):
             self.assertEqual(stringfile.getvalue(), '',
                              msg="logging.debug reports nothing when fancylogger loglevel is debug")
         else:
-            self.assertEqual(stringfile.getvalue(), msg,
+            self.assertEqual(stringfile.getvalue(), f'DEBUG:root:{msg}',
                              msg="logging.debug reports something when fancylogger loglevel is debug")
 
         fancylogger.setroot()

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 [tox]
-envlist = py36
+envlist = py36,py39
 skipsdist = true
 
 [testenv]

--- a/vsc-ci.ini
+++ b/vsc-ci.ini
@@ -1,2 +1,3 @@
 [vsc-ci]
 enable_github_actions=1
+py39_tests_must_pass=1


### PR DESCRIPTION
It seems that around python 3.7 log stream handling was changed. (can't find the actual change in the changelog)

 I believe this is a good thing as now "logging with logging" no longer disappears when using fancylogger, which used to happen. 
 
 We used to test specifically for this behaviour. How big the behaviour change is, I can't say. So I don't know if we should rework fancylogger or just disable the test. As I would like to get rid of fancylogger I would propose to just disable the test, as this "new" behaviour might make migrating away from facylogger easier.

but those are just my 50 cents.