### PR TITLE
make suppressing error messages an option

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
     - name: install tox

--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -442,7 +442,10 @@ class Run:
         cmd_ascii = ensure_ascii_string(self.cmd)
         if not self._process_exitcode == 0:
             shell_cmd_ascii = ensure_ascii_string(self._shellcmd)
-            message = f"_post_exitcode: problem occured with cmd {cmd_ascii}: (shellcmd {shell_cmd_ascii}) output {self._process_ouput}"
+            message = (
+                f"_post_exitcode: problem occured with cmd {cmd_ascii}:"
+                f"(shellcmd {shell_cmd_ascii}) output {self._process_ouput}"
+            )
             if self.post_exitcode:
                 self._post_exitcode_log_failure(message)
             else:

--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -442,7 +442,7 @@ class Run:
         cmd_ascii = ensure_ascii_string(self.cmd)
         if not self._process_exitcode == 0:
             shell_cmd_ascii = ensure_ascii_string(self._shellcmd)
-            message = f"_post_exitcode: problem occured with cmd {cmd_acii}: (shellcmd {shell_cmd_ascii}) output {self._process_ouput}"
+            message = f"_post_exitcode: problem occured with cmd {cmd_ascii}: (shellcmd {shell_cmd_ascii}) output {self._process_ouput}"
             if self.post_exitcode:
                 self._post_exitcode_log_failure(message)
             else:

--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -770,7 +770,7 @@ class RunNoShellFile(RunNoShell, RunFile):
 
 class RunPty(Run):
     """Pty support (eg for screen sessions)"""
-    hdef _read_process(self, readsize=None):
+    def _read_process(self, readsize=None):
         """This does not work for pty"""
         return ''
 

--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -444,7 +444,7 @@ class Run:
             shell_cmd_ascii = ensure_ascii_string(self._shellcmd)
             message = (
                 f"_post_exitcode: problem occured with cmd {cmd_ascii}:"
-                f"(shellcmd {shell_cmd_ascii}) output {self._process_ouput}"
+                f"(shellcmd {shell_cmd_ascii}) output {self._process_output}"
             )
             if self.post_exitcode:
                 self._post_exitcode_log_failure(message)

--- a/lib/vsc/utils/run.py
+++ b/lib/vsc/utils/run.py
@@ -160,7 +160,7 @@ class Run:
             @param use_shell: use the subshell
             @param shell: change the shell
             @param env: environment settings to pass on
-            @param post_exitcode: log errors on non zero exitcode
+            @param post_exitcode: log errors on non zero exitcode (debug otherwise)
         """
         self.input = kwargs.pop('input', None)
         self.startpath = kwargs.pop('startpath', None)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ag, kh, jt, sdw, wdp
 
 PACKAGE = {
-    'version': '3.6.1',
+    'version': '3.6.2',
     'author': [sdw, jt, ag, kh],
     'maintainer': [sdw, jt, ag, kh, wdp],
     'install_requires': [


### PR DESCRIPTION
by default run logs all errors from commands as new errors in it's log. although this is almost always wanted, it would be good to be able to suppress it for CLI tools. e.g. when running things like local monitoring.
it will send them to debug log instead.
