### PR TITLE
fancylogger: catch broader exceptions when importing mpi4py

### DIFF
--- a/lib/vsc/utils/fancylogger.py
+++ b/lib/vsc/utils/fancylogger.py
@@ -203,7 +203,7 @@ if not _env_to_boolean("FANCYLOGGER_IGNORE_MPI4PY"):
                 # enable mpi rank when mpi is used
                 FANCYLOG_FANCYRECORD = True
                 DEFAULT_LOGGING_FORMAT = DEFAULT_LOGGING_FORMAT_MPI
-    except ImportError:
+    except Exception:
         pass
 
 


### PR DESCRIPTION
In mixed Python environments, mpi4py import may raise exceptions other than ImportError (e.g. TypeError due to version mismatch). Broaden exception handling to avoid crashes and fall back gracefully.

To give some context: when using vsc-mympirun together with software bundles that include their own Python stack (e.g. [OpenFOAM](https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2412_250814-foss-2024a.eb) with ParaView), a conflicting mpi4py version may be picked up, leading to errors such as:

> RuntimeWarning: compiletime version 3.12 of module 'mpi4py.MPI' does not match runtime version 3.9
TypeError: 'co_linetable' is an invalid keyword argument for replace()

Since fancylogger is a logging utility, it should not cause the application to fail in such situations. With this change, it falls back to non-MPI logging when mpi4py cannot be safely imported.

Note: this change only covers Python-level exceptions. In some mixed Python environments, importing mpi4py may still trigger a hard crash (e.g. due to ABI mismatches) before the exception handler is reached. Avoiding the mpi4py import entirely would be a more robust solution in such cases.

(see also https://github.com/hpcugent/vsc-base/issues/216)